### PR TITLE
fix: returns `null` if hover is cancelled

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 2.1.5-alpha
+version = 2.1.6-alpha

--- a/src/main/java/ch/fhnw/thga/FregeTextDocumentService.java
+++ b/src/main/java/ch/fhnw/thga/FregeTextDocumentService.java
@@ -86,8 +86,7 @@ public class FregeTextDocumentService implements TextDocumentService {
 		String functionName = extractFirstWordFromLine(currentOpenFileContents, params.getPosition().getLine());
 		Optional<String> functionSignature = getFunctionTypeSignature(functionName, replEnv);
 		return CompletableFutures.computeAsync(cancel -> {
-			cancel.checkCanceled();
-			if (functionSignature.isEmpty()) {
+			if (functionSignature.isEmpty() || cancel.isCanceled()) {
 				return null;
 			} else {
 				return (new Hover(

--- a/src/main/java/ch/fhnw/thga/TypeSignature.java
+++ b/src/main/java/ch/fhnw/thga/TypeSignature.java
@@ -162,7 +162,7 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/TypeSignature.fr",
-  time=1629557926073L, jmajor=11, jminor=-1,
+  time=1629809715466L, jmajor=11, jminor=-1,
   imps={
     "frege.compiler.enums.Flags", "frege.interpreter.FregeInterpreter", "frege.repl.FregeRepl",
     "frege.control.monad.trans.MonadIO", "frege.Prelude", "frege.prelude.PreludeArrays", "frege.prelude.PreludeBase",

--- a/src/test/java/ch/fhnw/thga/FregeTextDocumentServiceTest.java
+++ b/src/test/java/ch/fhnw/thga/FregeTextDocumentServiceTest.java
@@ -193,7 +193,7 @@ class FregeTextDocumentServiceTest {
             CompletableFuture<Hover> actual = service.hover(hoverParams);
             actual.cancel(true);
             assertThrows(CancellationException.class, () -> {
-                actual.get(1, TimeUnit.SECONDS);
+                assertNull(actual.get(1, TimeUnit.SECONDS));
             });
         }
 


### PR DESCRIPTION
Return `null` according to the [lsp protocol](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_hover) if a hover is cancelled.