### PR TITLE
Split Compile from Language Feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version       = 3.2.0-alpha
+version       = 3.2.1-alpha
 gradleVersion = 7.4.2

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.fr
@@ -108,10 +108,8 @@ private compileSourceCode fregeCode = do
     g <- getSTT
     return g
 
-compile :: String -> IO Global -> IO Global
-compile fregeCode global = do
-    startGlobal <- global
-    execStateT (compileSourceCode fregeCode) startGlobal
+compile :: String -> Global -> IO Global
+compile fregeCode = execStateT $ compileSourceCode fregeCode
 
 runpass :: (StIO (String, Int), String) -> StIO ()
 runpass (pass, description) = do
@@ -126,9 +124,9 @@ shouldCorrectlyConfigureExtraClasspath = once $ morallyDubiousIOProperty do
         "module FregeFxDep where\n\n"++ 
         "import fregefx.JavaFxType\n\n" ++ 
         "main = println \"Hello FregeFX\""
-    fregefxGlobal = CompileGlobal.fromOptions standardCompileOptions.
+    fregefxGlobal          <- CompileGlobal.fromOptions standardCompileOptions.
         {
             path = [ "./src/main/resources/fregefx-0.8.2-SNAPSHOT.jar" ]
         }
-    actual <- compile fregeCodeWithDependency fregefxGlobal
-    pure    $ actual.errors == 0
+    actual                 <- compile fregeCodeWithDependency fregefxGlobal
+    pure                    $ actual.errors == 0

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.fr
@@ -67,30 +67,23 @@ extractDiagnostics = do
     diagnostics = fmap createDiagnosticFromMessage gl.sub.messages
     sequence diagnostics
 
--- TODO: change to Global -> IO [ Diagnostic ]
-getDiagnostics :: IO Global -> IO [ Diagnostic ]
-getDiagnostics global = do
-    gl  <- global
-    pure $ evalState (extractDiagnostics) gl
-
--- TODO: remove if everything works
-compileAndGetDiagnostics :: String -> IO [ Diagnostic ]
-compileAndGetDiagnostics fregeCode = do
-    gl          <- compile fregeCode standardCompileGlobal
-    pure         $ evalState (extractDiagnostics) gl
+getDiagnostics :: Global -> [ Diagnostic ]
+getDiagnostics = evalState $ extractDiagnostics
 
 fregeLSPServerShouldMapNoCompilerMessagesToEmptyArray :: Property
 fregeLSPServerShouldMapNoCompilerMessagesToEmptyArray = once $ morallyDubiousIOProperty do
     fregeCodeWithoutError = "module CorrectFregeTest where\n\n" ++ "ok = 42 + 42"
-    gl                    = compile fregeCodeWithoutError standardCompileGlobal 
+    global               <- standardCompileGlobal
+    compiledGlobal       <- compile fregeCodeWithoutError global
     expected              = []
-    actual               <- getDiagnostics gl
+    actual                = getDiagnostics compiledGlobal
     pure                  $ expected == actual
 
 fregeLSPServerShouldMapSingleCompilerMessageToDiagnostics :: Property
 fregeLSPServerShouldMapSingleCompilerMessageToDiagnostics = once $ morallyDubiousIOProperty do
     fregeCodeWithError = "module ch.fhnw.thga.FaultyFregeTest where\n\nimport Does.not.Exist"
-    gl                 = compile fregeCodeWithError standardCompileGlobal 
+    global            <- standardCompileGlobal
+    compiledGlobal    <- compile fregeCodeWithError global
     expected           = 
         [ 
             Diagnostic 
@@ -101,13 +94,14 @@ fregeLSPServerShouldMapSingleCompilerMessageToDiagnostics = once $ morallyDubiou
                 message  = "Could not import module frege.does.not.Exist\n(java.lang.ClassNotFoundException: frege.does.not.Exist)" 
             } 
         ]
-    actual <- getDiagnostics gl
+    actual  = getDiagnostics compiledGlobal
     pure    $ expected == actual
 
 fregeLSPServerShouldMapMultipleCompilerMessageToDiagnostics :: Property
 fregeLSPServerShouldMapMultipleCompilerMessageToDiagnostics = once $ morallyDubiousIOProperty do
     fregeCodeWithErrors = "module ch.fhnw.thga.FaultyFregeTest where\n\nerr1 = do\n  x = 42\n\nerr2 = [ 22.0 ] ++ \"42\"\n\nerr3 = 42 + \"42\""
-    gl                  = compile fregeCodeWithErrors standardCompileGlobal 
+    global             <- standardCompileGlobal
+    compiledGlobal     <- compile fregeCodeWithErrors global 
     expected            = 
         [ 
             Diagnostic 
@@ -132,7 +126,7 @@ fregeLSPServerShouldMapMultipleCompilerMessageToDiagnostics = once $ morallyDubi
                 message  = "last statement in a monadic do block must not\nbe let decls" 
             }
         ]
-    actual <- getDiagnostics gl
+    actual  = getDiagnostics compiledGlobal
     pure    $ expected == actual
 
 posToTokens :: [ TokenPosition ] -> Global -> [ Token ]
@@ -143,7 +137,8 @@ main :: IO ()
 main = do
     let fregeCode       = "module ch.fhnw.thga.FaultyFregeTest where\n\nerr1 = do\n  x = 42\n\nerr2 = [ 22.0 ] ++ \"42\"\n\nerr3 = 42 + \"42\"\n\n"
     let trickyFregeCode = "module FaultyFregeTest where\n\nsimplyString s = s\n\nerr1 = (simplyString 42) ++ \"test\""
-    gl                 <- compile trickyFregeCode standardCompileGlobal
+    global             <- standardCompileGlobal 
+    gl                 <- compile trickyFregeCode global
     println             $ CharSequence.toString gl.sub.code
     for gl.sub.messages println
     let positions      = map (Message.pos) gl.sub.messages

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.fr
@@ -67,6 +67,13 @@ extractDiagnostics = do
     diagnostics = fmap createDiagnosticFromMessage gl.sub.messages
     sequence diagnostics
 
+-- TODO: change to Global -> IO [ Diagnostic ]
+getDiagnostics :: IO Global -> IO [ Diagnostic ]
+getDiagnostics global = do
+    gl  <- global
+    pure $ evalState (extractDiagnostics) gl
+
+-- TODO: remove if everything works
 compileAndGetDiagnostics :: String -> IO [ Diagnostic ]
 compileAndGetDiagnostics fregeCode = do
     gl          <- compile fregeCode standardCompileGlobal
@@ -75,13 +82,15 @@ compileAndGetDiagnostics fregeCode = do
 fregeLSPServerShouldMapNoCompilerMessagesToEmptyArray :: Property
 fregeLSPServerShouldMapNoCompilerMessagesToEmptyArray = once $ morallyDubiousIOProperty do
     fregeCodeWithoutError = "module CorrectFregeTest where\n\n" ++ "ok = 42 + 42"
+    gl                    = compile fregeCodeWithoutError standardCompileGlobal 
     expected              = []
-    actual               <- compileAndGetDiagnostics fregeCodeWithoutError
+    actual               <- getDiagnostics gl
     pure                  $ expected == actual
 
 fregeLSPServerShouldMapSingleCompilerMessageToDiagnostics :: Property
 fregeLSPServerShouldMapSingleCompilerMessageToDiagnostics = once $ morallyDubiousIOProperty do
     fregeCodeWithError = "module ch.fhnw.thga.FaultyFregeTest where\n\nimport Does.not.Exist"
+    gl                 = compile fregeCodeWithError standardCompileGlobal 
     expected           = 
         [ 
             Diagnostic 
@@ -92,13 +101,13 @@ fregeLSPServerShouldMapSingleCompilerMessageToDiagnostics = once $ morallyDubiou
                 message  = "Could not import module frege.does.not.Exist\n(java.lang.ClassNotFoundException: frege.does.not.Exist)" 
             } 
         ]
-    gl     <- standardCompileGlobal
-    actual <- compileAndGetDiagnostics fregeCodeWithError
+    actual <- getDiagnostics gl
     pure    $ expected == actual
 
 fregeLSPServerShouldMapMultipleCompilerMessageToDiagnostics :: Property
 fregeLSPServerShouldMapMultipleCompilerMessageToDiagnostics = once $ morallyDubiousIOProperty do
     fregeCodeWithErrors = "module ch.fhnw.thga.FaultyFregeTest where\n\nerr1 = do\n  x = 42\n\nerr2 = [ 22.0 ] ++ \"42\"\n\nerr3 = 42 + \"42\""
+    gl                  = compile fregeCodeWithErrors standardCompileGlobal 
     expected            = 
         [ 
             Diagnostic 
@@ -123,8 +132,7 @@ fregeLSPServerShouldMapMultipleCompilerMessageToDiagnostics = once $ morallyDubi
                 message  = "last statement in a monadic do block must not\nbe let decls" 
             }
         ]
-    gl     <- standardCompileGlobal
-    actual <- compileAndGetDiagnostics fregeCodeWithErrors
+    actual <- getDiagnostics gl
     pure    $ expected == actual
 
 posToTokens :: [ TokenPosition ] -> Global -> [ Token ]

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.fr
@@ -1,9 +1,10 @@
 module ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP where
 
 import ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic (
-    DiagnosticSeverity, Diagnostic, compileAndGetDiagnostics)
-
+    DiagnosticSeverity, Diagnostic, compileAndGetDiagnostics, getDiagnostics)
 import ch.fhnw.thga.fregelanguageserver.lsp4j.RangeLSP4J (RangeLSP)
+import Compiler.types.Global (Global)
+import Control.monad.State (evalState)
 
 data DiagnosticSeverityLSP = pure native org.eclipse.lsp4j.DiagnosticSeverity where
     pure native error       "org.eclipse.lsp4j.DiagnosticSeverity.Error"       :: DiagnosticSeverityLSP
@@ -37,6 +38,13 @@ data ArrayList a = native java.util.ArrayList where
     go :: [a] -> Mutable s (ArrayList a) -> STMutable s (ArrayList a)
     go [] list     = return list
     go (x:xs) list = ArrayList.add list x >> go xs list
+
+-- TODO: change to Global -> IO (ArrayList DiagnosticLSP)
+getDiagnosticsLSP :: IO Global -> IOMutable (ArrayList DiagnosticLSP)
+getDiagnosticsLSP global = do
+    diagnostics   <- getDiagnostics global
+    diagnosticsLSP = DiagnosticLSP.fromDiagnostic <$> diagnostics
+    ArrayList.fromFregeList diagnosticsLSP
 
 compileAndGetDiagnosticsLSP :: String -> IOMutable (ArrayList DiagnosticLSP)
 compileAndGetDiagnosticsLSP fregeCode = do

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.fr
@@ -2,7 +2,6 @@ module ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP where
 
 import ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic (
     DiagnosticSeverity, Diagnostic, compileAndGetDiagnostics)
-import ch.fhnw.thga.fregelanguageserver.compiler.CompilerHelper(standardLSPGlobal)
 
 import ch.fhnw.thga.fregelanguageserver.lsp4j.RangeLSP4J (RangeLSP)
 

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.fr
@@ -2,6 +2,7 @@ module ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP where
 
 import ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic (
     DiagnosticSeverity, Diagnostic, compileAndGetDiagnostics)
+import ch.fhnw.thga.fregelanguageserver.compiler.CompilerHelper(standardLSPGlobal)
 
 import ch.fhnw.thga.fregelanguageserver.lsp4j.RangeLSP4J (RangeLSP)
 

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.fr
@@ -1,7 +1,7 @@
 module ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP where
 
 import ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic (
-    DiagnosticSeverity, Diagnostic, compileAndGetDiagnostics, getDiagnostics)
+    DiagnosticSeverity, Diagnostic, getDiagnostics)
 import ch.fhnw.thga.fregelanguageserver.lsp4j.RangeLSP4J (RangeLSP)
 import Compiler.types.Global (Global)
 import Control.monad.State (evalState)
@@ -39,15 +39,10 @@ data ArrayList a = native java.util.ArrayList where
     go [] list     = return list
     go (x:xs) list = ArrayList.add list x >> go xs list
 
--- TODO: change to Global -> IO (ArrayList DiagnosticLSP)
-getDiagnosticsLSP :: IO Global -> IOMutable (ArrayList DiagnosticLSP)
+getDiagnosticsLSP :: Global -> STMutable s (ArrayList DiagnosticLSP)
 getDiagnosticsLSP global = do
-    diagnostics   <- getDiagnostics global
+    diagnostics    = getDiagnostics global
     diagnosticsLSP = DiagnosticLSP.fromDiagnostic <$> diagnostics
     ArrayList.fromFregeList diagnosticsLSP
 
-compileAndGetDiagnosticsLSP :: String -> IOMutable (ArrayList DiagnosticLSP)
-compileAndGetDiagnosticsLSP fregeCode = do
-    diagnostics   <- compileAndGetDiagnostics fregeCode
-    diagnosticsLSP = DiagnosticLSP.fromDiagnostic <$> diagnostics
-    ArrayList.fromFregeList diagnosticsLSP
+main = println "hello DiagnosticLSP"

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr
@@ -34,14 +34,14 @@ derive Show Hover
 
 getSymbolType:: Symbol -> StateT Global Maybe String
 getSymbolType sym = do
-    gl <- StateT.get
-    pure $ label gl sym
+    global <- StateT.get
+    pure   $ label global sym
 
 findToken :: Position -> StateT Global Maybe Token
 findToken pos = do
-    gl <- StateT.get
-    tokens = listFromArray gl.sub.toks
-    lift $ find isHoverOverToken tokens where
+    global <- StateT.get
+    tokens = listFromArray global.sub.toks
+    lift   $ find isHoverOverToken tokens where
         isHoverOverToken :: Token -> Bool
         isHoverOverToken t = 
             pos.line      == t.line && 
@@ -50,20 +50,26 @@ findToken pos = do
 
 findSymbol :: QName -> StateT Global Maybe Symbol
 findSymbol qname = do
-    gl  <- StateT.get
-    lift $ Global.find gl qname
+    global  <- StateT.get
+    lift     $ Global.find global qname
 
 tokenToQName :: Token -> StateT Global Maybe QName
 tokenToQName t = do
-    g <- StateT.get
-    namespaceOrVariable <- lift $ Global.resolved g t
-    lift $ either (const Nothing) Just namespaceOrVariable
+    global              <- StateT.get
+    namespaceOrVariable <- lift $ Global.resolved global t
+    lift                 $ either (const Nothing) Just namespaceOrVariable
 
 compileAndGetTypeSignatureOnHover :: String -> Position -> IO (Maybe Hover)
 compileAndGetTypeSignatureOnHover fregeCode pos = do
     startGlobal <- standardCompileGlobal
     gl          <- compile fregeCode standardCompileGlobal
     pure         $ evalStateT (getTypeOnHover pos) gl
+
+-- TODO: change to Global -> Position -> IO (Maybe Hover)
+getTypeSignatureOnHover :: IO Global -> Position -> IO (Maybe Hover)
+getTypeSignatureOnHover ioGlobal pos = do
+    global  <- ioGlobal
+    pure     $ evalStateT (getTypeOnHover pos) global
 
 getTypeOnHover :: Position -> StateT Global Maybe Hover
 getTypeOnHover pos = do
@@ -72,90 +78,104 @@ getTypeOnHover pos = do
     qname      <- tokenToQName token
     symbol     <- findSymbol qname
     symbolType <- getSymbolType symbol
-    pure        $ Hover { 
-        range   = tokenToRange token, 
-        content = FregeCodeBlock symbolType
-    }
+    pure        $ Hover 
+        { 
+            range   = tokenToRange token, 
+            content = FregeCodeBlock symbolType
+        }
 
 shouldShowLocalVaridTypeSignature :: Property
 shouldShowLocalVaridTypeSignature = once $ morallyDubiousIOProperty do
     fregeHoverCode = "module HoverTest where\n\n" ++ "simplyString = \"Hello\""
-    expected = Just Hover { 
-        range   = Range { start = Position 3 1, end = Position 3 13 },
-        content = FregeCodeBlock "simplyString :: String"
-    }
-    actual <- compileAndGetTypeSignatureOnHover fregeHoverCode (Position 3 3)
-    pure    $ expected == actual
+    global         = compile fregeHoverCode standardCompileGlobal
+    expected       = Just Hover 
+        { 
+            range   = Range { start = Position 3 1, end = Position 3 13 },
+            content = FregeCodeBlock "simplyString :: String"
+        }
+    actual        <- getTypeSignatureOnHover global (Position 3 3)
+    pure           $ expected == actual
 
 shouldShowImportedVaridTypeSignature :: Property
 shouldShowImportedVaridTypeSignature = once $ morallyDubiousIOProperty do
     fregeHoverCode = "module HoverTest where\n\n" ++ "main = println \"Hello\""
-    expected = Just Hover { 
-        range   = Range { start = Position 3 8, end = Position 3 15 },
-        content = FregeCodeBlock "println :: Show 𝖆 => 𝖆 -> IO ()"
-    }
-    actual <- compileAndGetTypeSignatureOnHover fregeHoverCode (Position 3 9)
-    pure    $ expected == actual
+    global         = compile fregeHoverCode standardCompileGlobal
+    expected       = Just Hover 
+        { 
+            range   = Range { start = Position 3 8, end = Position 3 15 },
+            content = FregeCodeBlock "println :: Show 𝖆 => 𝖆 -> IO ()"
+        }
+    actual         <- getTypeSignatureOnHover global (Position 3 9)
+    pure            $ expected == actual
 
 shouldShowLocalConidTypeSignature :: Property
 shouldShowLocalConidTypeSignature = once $ morallyDubiousIOProperty do
     fregeHoverCode = "module HoverTest where\n\n"
-        ++ "data MyMaybe a = MyNothing | MyJust a\n"
-    expected = Just Hover { 
-        range   = Range { start = Position 3 6, end = Position 3 13 },
-        content = FregeCodeBlock "MyMaybe :: *->*"
-    }
-    actual <- compileAndGetTypeSignatureOnHover fregeHoverCode (Position 3 7)
-    pure    $ expected == actual
+                  ++ "data MyMaybe a = MyNothing | MyJust a\n"
+    global         = compile fregeHoverCode standardCompileGlobal
+    expected       = Just Hover 
+        { 
+            range   = Range { start = Position 3 6, end = Position 3 13 },
+            content = FregeCodeBlock "MyMaybe :: *->*"
+        }
+    actual         <- getTypeSignatureOnHover global (Position 3 7)
+    pure            $ expected == actual
 
 shouldShowImportedConidTypeSignature :: Property
 shouldShowImportedConidTypeSignature = once $ morallyDubiousIOProperty do
     fregeHoverCode = "module HoverTest where\n\n"
-        ++ "import frege.data.Maybe(Maybe)"
-    expected = Just Hover { 
-        range   = Range { start = Position 3 25, end = Position 3 30 },
-        content = FregeCodeBlock "Maybe :: *->*"
-    }
-    actual <- compileAndGetTypeSignatureOnHover fregeHoverCode (Position 3 27)
-    pure    $ expected == actual
+                  ++ "import frege.data.Maybe(Maybe)"
+    global         = compile fregeHoverCode standardCompileGlobal
+    expected       = Just Hover 
+        { 
+            range   = Range { start = Position 3 25, end = Position 3 30 },
+            content = FregeCodeBlock "Maybe :: *->*"
+        }
+    actual         <- getTypeSignatureOnHover global (Position 3 27)
+    pure           $  expected == actual
 
 shouldShowLocalConidDataConstructor :: Property
 shouldShowLocalConidDataConstructor = once $ morallyDubiousIOProperty do
     fregeHoverCode = "module HoverTest where\n\n"
-        ++ "data MyMaybe a = MyNothing | MyJust a\n"
-        ++ "res = MyJust 42"
-    expected = Just Hover { 
-        range   = Range { start = Position 4 7, end = Position 4 13 },
-        content = FregeCodeBlock "MyJust :: a -> MyMaybe a"
-    }
-    actual <- compileAndGetTypeSignatureOnHover fregeHoverCode (Position 4 8)
-    pure    $ expected == actual
+                  ++ "data MyMaybe a = MyNothing | MyJust a\n"
+                  ++ "res = MyJust 42"
+    global         = compile fregeHoverCode standardCompileGlobal
+    expected       = Just Hover 
+        { 
+            range   = Range { start = Position 4 7, end = Position 4 13 },
+            content = FregeCodeBlock "MyJust :: a -> MyMaybe a"
+        }
+    actual         <- getTypeSignatureOnHover global (Position 4 8)
+    pure            $ expected == actual
 
 shouldShowImportedConidDataConstructor :: Property
 shouldShowImportedConidDataConstructor = once $ morallyDubiousIOProperty do
     fregeHoverCode = "module HoverTest where\n\n"
-        ++ "import frege.data.Maybe(Maybe, Just)\n"
-        ++ "res = Just 42"
-    expected = Just Hover { 
-        range   = Range { start = Position 4 7, end = Position 4 11 },
-        content = FregeCodeBlock "Just :: a -> Maybe a"
-    }
-    actual <- compileAndGetTypeSignatureOnHover fregeHoverCode (Position 4 10)
-    pure    $ expected == actual
+                  ++ "import frege.data.Maybe(Maybe, Just)\n"
+                  ++ "res = Just 42"
+    global         = compile fregeHoverCode standardCompileGlobal
+    expected       = Just Hover 
+        { 
+            range   = Range { start = Position 4 7, end = Position 4 11 },
+            content = FregeCodeBlock "Just :: a -> Maybe a"
+        }
+    actual         <- getTypeSignatureOnHover global (Position 4 10)
+    pure            $ expected == actual
 
 main :: IO ()
 main = do
-    let fregeCode = "module HoverTest where\n\n" 
-            ++ "import frege.compiler.Main(runpass)\n\n"
-            ++ "pass = runpass\n" ++ "me = 42\n\n"
-            ++ "main = do\n  a = \"Hello\"\n  println a"
+    let fregeCode       = "module HoverTest where\n\n" 
+                       ++ "import frege.compiler.Main(runpass)\n\n"
+                       ++ "pass = runpass\n" ++ "me = 42\n\n"
+                       ++ "main = do\n  a = \"Hello\"\n  println a"
+    
     let simpleFregeCode = "module HoverTest where\n\n" 
-            ++ "data MyMaybe a = MyNothing | MyJust a\n"
-            ++ "res = MyJust 42"
-    gl            <- compile fregeCode standardCompileGlobal
-    println $ CharSequence.toString gl.sub.code
-    tokens = listFromArray gl.sub.toks
+                       ++ "data MyMaybe a = MyNothing | MyJust a\n"
+                       ++ "res = MyJust 42"
+    global             <- compile fregeCode standardCompileGlobal
+    println             $ CharSequence.toString global.sub.code
+    tokens              = listFromArray global.sub.toks
     for tokens println
-    hover <- compileAndGetTypeSignatureOnHover fregeCode (Position 5 9)
+    hover             <- getTypeSignatureOnHover (pure global) (Position 5 9)
     println hover
     println "end"

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr
@@ -59,17 +59,8 @@ tokenToQName t = do
     namespaceOrVariable <- lift $ Global.resolved global t
     lift                 $ either (const Nothing) Just namespaceOrVariable
 
-compileAndGetTypeSignatureOnHover :: String -> Position -> IO (Maybe Hover)
-compileAndGetTypeSignatureOnHover fregeCode pos = do
-    startGlobal <- standardCompileGlobal
-    gl          <- compile fregeCode standardCompileGlobal
-    pure         $ evalStateT (getTypeOnHover pos) gl
-
--- TODO: change to Global -> Position -> IO (Maybe Hover)
-getTypeSignatureOnHover :: IO Global -> Position -> IO (Maybe Hover)
-getTypeSignatureOnHover ioGlobal pos = do
-    global  <- ioGlobal
-    pure     $ evalStateT (getTypeOnHover pos) global
+getTypeSignatureOnHover :: Position -> Global -> Maybe Hover
+getTypeSignatureOnHover pos = evalStateT $ getTypeOnHover pos
 
 getTypeOnHover :: Position -> StateT Global Maybe Hover
 getTypeOnHover pos = do
@@ -86,52 +77,56 @@ getTypeOnHover pos = do
 
 shouldShowLocalVaridTypeSignature :: Property
 shouldShowLocalVaridTypeSignature = once $ morallyDubiousIOProperty do
-    fregeHoverCode = "module HoverTest where\n\n" ++ "simplyString = \"Hello\""
-    global         = compile fregeHoverCode standardCompileGlobal
+    fregeHoverCode  = "module HoverTest where\n\n" ++ "simplyString = \"Hello\""
+    global         <- standardCompileGlobal
+    compiledGlobal <- compile fregeHoverCode global
     expected       = Just Hover 
         { 
             range   = Range { start = Position 3 1, end = Position 3 13 },
             content = FregeCodeBlock "simplyString :: String"
         }
-    actual        <- getTypeSignatureOnHover global (Position 3 3)
+    actual         = getTypeSignatureOnHover (Position 3 3) compiledGlobal
     pure           $ expected == actual
 
 shouldShowImportedVaridTypeSignature :: Property
 shouldShowImportedVaridTypeSignature = once $ morallyDubiousIOProperty do
     fregeHoverCode = "module HoverTest where\n\n" ++ "main = println \"Hello\""
-    global         = compile fregeHoverCode standardCompileGlobal
+    global         <- standardCompileGlobal
+    compiledGlobal <- compile fregeHoverCode global
     expected       = Just Hover 
         { 
             range   = Range { start = Position 3 8, end = Position 3 15 },
             content = FregeCodeBlock "println :: Show 𝖆 => 𝖆 -> IO ()"
         }
-    actual         <- getTypeSignatureOnHover global (Position 3 9)
+    actual          = getTypeSignatureOnHover (Position 3 9) compiledGlobal
     pure            $ expected == actual
 
 shouldShowLocalConidTypeSignature :: Property
 shouldShowLocalConidTypeSignature = once $ morallyDubiousIOProperty do
     fregeHoverCode = "module HoverTest where\n\n"
                   ++ "data MyMaybe a = MyNothing | MyJust a\n"
-    global         = compile fregeHoverCode standardCompileGlobal
+    global         <- standardCompileGlobal
+    compiledGlobal <- compile fregeHoverCode global
     expected       = Just Hover 
         { 
             range   = Range { start = Position 3 6, end = Position 3 13 },
             content = FregeCodeBlock "MyMaybe :: *->*"
         }
-    actual         <- getTypeSignatureOnHover global (Position 3 7)
+    actual          = getTypeSignatureOnHover (Position 3 7) compiledGlobal
     pure            $ expected == actual
 
 shouldShowImportedConidTypeSignature :: Property
 shouldShowImportedConidTypeSignature = once $ morallyDubiousIOProperty do
     fregeHoverCode = "module HoverTest where\n\n"
                   ++ "import frege.data.Maybe(Maybe)"
-    global         = compile fregeHoverCode standardCompileGlobal
+    global         <- standardCompileGlobal
+    compiledGlobal <- compile fregeHoverCode global
     expected       = Just Hover 
         { 
             range   = Range { start = Position 3 25, end = Position 3 30 },
             content = FregeCodeBlock "Maybe :: *->*"
         }
-    actual         <- getTypeSignatureOnHover global (Position 3 27)
+    actual          = getTypeSignatureOnHover (Position 3 27) compiledGlobal
     pure           $  expected == actual
 
 shouldShowLocalConidDataConstructor :: Property
@@ -139,13 +134,14 @@ shouldShowLocalConidDataConstructor = once $ morallyDubiousIOProperty do
     fregeHoverCode = "module HoverTest where\n\n"
                   ++ "data MyMaybe a = MyNothing | MyJust a\n"
                   ++ "res = MyJust 42"
-    global         = compile fregeHoverCode standardCompileGlobal
+    global         <- standardCompileGlobal
+    compiledGlobal <- compile fregeHoverCode global
     expected       = Just Hover 
         { 
             range   = Range { start = Position 4 7, end = Position 4 13 },
             content = FregeCodeBlock "MyJust :: a -> MyMaybe a"
         }
-    actual         <- getTypeSignatureOnHover global (Position 4 8)
+    actual          = getTypeSignatureOnHover (Position 4 8) compiledGlobal
     pure            $ expected == actual
 
 shouldShowImportedConidDataConstructor :: Property
@@ -153,13 +149,14 @@ shouldShowImportedConidDataConstructor = once $ morallyDubiousIOProperty do
     fregeHoverCode = "module HoverTest where\n\n"
                   ++ "import frege.data.Maybe(Maybe, Just)\n"
                   ++ "res = Just 42"
-    global         = compile fregeHoverCode standardCompileGlobal
+    global         <- standardCompileGlobal
+    compiledGlobal <- compile fregeHoverCode global
     expected       = Just Hover 
         { 
             range   = Range { start = Position 4 7, end = Position 4 11 },
             content = FregeCodeBlock "Just :: a -> Maybe a"
         }
-    actual         <- getTypeSignatureOnHover global (Position 4 10)
+    actual          = getTypeSignatureOnHover (Position 4 10) compiledGlobal
     pure            $ expected == actual
 
 main :: IO ()
@@ -172,10 +169,11 @@ main = do
     let simpleFregeCode = "module HoverTest where\n\n" 
                        ++ "data MyMaybe a = MyNothing | MyJust a\n"
                        ++ "res = MyJust 42"
-    global             <- compile fregeCode standardCompileGlobal
-    println             $ CharSequence.toString global.sub.code
-    tokens              = listFromArray global.sub.toks
+    global             <- standardCompileGlobal
+    compiledGlobal     <- compile fregeCode global
+    println             $ CharSequence.toString compiledGlobal.sub.code
+    tokens              = listFromArray compiledGlobal.sub.toks
     for tokens println
-    hover             <- getTypeSignatureOnHover (pure global) (Position 5 9)
+    hover               = getTypeSignatureOnHover (Position 5 9) compiledGlobal
     println hover
     println "end"

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/HoverLSP.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/HoverLSP.fr
@@ -2,7 +2,7 @@ module ch.fhnw.thga.fregelanguageserver.hover.HoverLSP where
 
 import ch.fhnw.thga.fregelanguageserver.lsp4j.PositionLSP4J (PositionLSP)
 import ch.fhnw.thga.fregelanguageserver.lsp4j.RangeLSP4J (RangeLSP)
-import ch.fhnw.thga.fregelanguageserver.hover.Hover (Hover, getTypeSignatureOnHover, compileAndGetTypeSignatureOnHover)
+import ch.fhnw.thga.fregelanguageserver.hover.Hover (Hover, getTypeSignatureOnHover)
 import Compiler.types.Global (Global)
 import Control.monad.State (evalState)
 
@@ -22,16 +22,9 @@ data HoverLSP = pure native org.eclipse.lsp4j.Hover where
             (MarkupContentLSP.new MarkupKindLSP.markdown (show content))
             (RangeLSP.fromRange range)
 
--- TODO: Change to Global -> PositionLSP -> IO (Maybe HoverLSP)
-getTypeSignatureOnHoverLSP :: IO Global -> PositionLSP -> IO (Maybe HoverLSP)
-getTypeSignatureOnHoverLSP global posLSP = do
-    hover <- getTypeSignatureOnHover global (PositionLSP.toPosition posLSP)
-    pure $ fmap HoverLSP.fromHover hover
+getTypeSignatureOnHoverLSP :: PositionLSP -> Global -> Maybe HoverLSP
+getTypeSignatureOnHoverLSP posLSP global = do
+    hover <- getTypeSignatureOnHover (PositionLSP.toPosition posLSP) global
+    pure   $ HoverLSP.fromHover hover
 
--- TODO: remove if everything works
-compileAndGetTypeSignatureOnHoverLSP :: String -> PositionLSP -> IO (Maybe HoverLSP)
-compileAndGetTypeSignatureOnHoverLSP fregeCode posLSP = do
-    hover <- compileAndGetTypeSignatureOnHover fregeCode (PositionLSP.toPosition posLSP)
-    pure $ fmap HoverLSP.fromHover hover
-
-main = println "hello"
+main = println "hello HoverLSP"

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/HoverLSP.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/HoverLSP.fr
@@ -2,7 +2,9 @@ module ch.fhnw.thga.fregelanguageserver.hover.HoverLSP where
 
 import ch.fhnw.thga.fregelanguageserver.lsp4j.PositionLSP4J (PositionLSP)
 import ch.fhnw.thga.fregelanguageserver.lsp4j.RangeLSP4J (RangeLSP)
-import ch.fhnw.thga.fregelanguageserver.hover.Hover (Hover, compileAndGetTypeSignatureOnHover)
+import ch.fhnw.thga.fregelanguageserver.hover.Hover (Hover, getTypeSignatureOnHover, compileAndGetTypeSignatureOnHover)
+import Compiler.types.Global (Global)
+import Control.monad.State (evalState)
 
 data MarkupContentLSP = pure native org.eclipse.lsp4j.MarkupContent where
     pure native new :: String -> String -> MarkupContentLSP
@@ -14,15 +16,22 @@ data MarkupKindLSP = pure native org.eclipse.lsp4j.MarkupKind where
 data HoverLSP = pure native org.eclipse.lsp4j.Hover where
     pure native new :: MarkupContentLSP -> RangeLSP -> HoverLSP
 
-    hoverToHoverLSP :: Hover -> HoverLSP
-    hoverToHoverLSP Hover { range, content } =
+    fromHover :: Hover -> HoverLSP
+    fromHover Hover { range, content } =
         HoverLSP.new 
             (MarkupContentLSP.new MarkupKindLSP.markdown (show content))
             (RangeLSP.fromRange range)
 
+-- TODO: Change to Global -> PositionLSP -> IO (Maybe HoverLSP)
+getTypeSignatureOnHoverLSP :: IO Global -> PositionLSP -> IO (Maybe HoverLSP)
+getTypeSignatureOnHoverLSP global posLSP = do
+    hover <- getTypeSignatureOnHover global (PositionLSP.toPosition posLSP)
+    pure $ fmap HoverLSP.fromHover hover
+
+-- TODO: remove if everything works
 compileAndGetTypeSignatureOnHoverLSP :: String -> PositionLSP -> IO (Maybe HoverLSP)
 compileAndGetTypeSignatureOnHoverLSP fregeCode posLSP = do
     hover <- compileAndGetTypeSignatureOnHover fregeCode (PositionLSP.toPosition posLSP)
-    pure $ fmap HoverLSP.hoverToHoverLSP hover
+    pure $ fmap HoverLSP.fromHover hover
 
 main = println "hello"

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/FregeLanguageServer.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/FregeLanguageServer.java
@@ -12,15 +12,22 @@ import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
 
+import ch.fhnw.thga.fregelanguageserver.compile.CompileOptions;
+import frege.compiler.types.Global.TOptions;
+import frege.run8.Lazy;
+
 public class FregeLanguageServer implements LanguageServer, LanguageClientAware 
 {
 	private final TextDocumentService textService;
 	private final WorkspaceService workspaceService;
 	private LanguageClient client;
+    private TOptions compileOptions;
+
 	public FregeLanguageServer()
     {
 		textService      = new FregeTextDocumentService(this);
 		workspaceService = new FregeWorkspaceService();
+        compileOptions   = CompileOptions.standardCompileOptions.call();
 	}
 
     public LanguageClient getClient()
@@ -28,9 +35,15 @@ public class FregeLanguageServer implements LanguageServer, LanguageClientAware
         return client;
     }
 
+    public TOptions getCompileOptions()
+    {
+        return compileOptions;
+    }
+
 	@Override
 	public CompletableFuture<InitializeResult> initialize(InitializeParams params)
     {
+        compileOptions = CompileOptions.standardCompileOptions.call();
 		final InitializeResult res = new InitializeResult(new ServerCapabilities());
 		res.getCapabilities().setTextDocumentSync(TextDocumentSyncKind.Full);
 		res.getCapabilities().setHoverProvider(true);

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/FregeLanguageServer.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/FregeLanguageServer.java
@@ -1,5 +1,7 @@
 package ch.fhnw.thga.fregelanguageserver;
 
+import static frege.prelude.PreludeBase.TST.performUnsafe;
+
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.lsp4j.InitializeParams;
@@ -12,22 +14,19 @@ import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
 
+import ch.fhnw.thga.fregelanguageserver.compile.CompileGlobal;
 import ch.fhnw.thga.fregelanguageserver.compile.CompileOptions;
-import frege.compiler.types.Global.TOptions;
-import frege.run8.Lazy;
 
 public class FregeLanguageServer implements LanguageServer, LanguageClientAware 
 {
-	private final TextDocumentService textService;
+	private final FregeTextDocumentService textService;
 	private final WorkspaceService workspaceService;
 	private LanguageClient client;
-    private TOptions compileOptions;
 
 	public FregeLanguageServer()
     {
 		textService      = new FregeTextDocumentService(this);
 		workspaceService = new FregeWorkspaceService();
-        compileOptions   = CompileOptions.standardCompileOptions.call();
 	}
 
     public LanguageClient getClient()
@@ -35,15 +34,17 @@ public class FregeLanguageServer implements LanguageServer, LanguageClientAware
         return client;
     }
 
-    public TOptions getCompileOptions()
-    {
-        return compileOptions;
-    }
-
 	@Override
 	public CompletableFuture<InitializeResult> initialize(InitializeParams params)
     {
-        compileOptions = CompileOptions.standardCompileOptions.call();
+        textService.setGlobal
+        (
+            performUnsafe
+            (
+                CompileGlobal
+                .fromOptions(CompileOptions.standardCompileOptions.call()).call()
+            ).call()
+        );
 		final InitializeResult res = new InitializeResult(new ServerCapabilities());
 		res.getCapabilities().setTextDocumentSync(TextDocumentSyncKind.Full);
 		res.getCapabilities().setHoverProvider(true);

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.java
@@ -387,6 +387,41 @@ final public static State.TState<Global.TGlobal, Global.TGlobal> switchState(fin
                 })
           );
 }
+final public static Lazy<Global.TOptions> standardLSPOptions = Thunk.<Global.TOptions>shared(
+      (Lazy<Global.TOptions>)(() -> {
+            return Global.TOptions.mk(
+                      "-",
+                      PreludeBase.TList.DCons.<String/*<Character>*/>mk(
+                            Thunk.<String/*<Character>*/>lazy("."), PreludeBase.TList.DList.<String/*<Character>*/>mk()
+                          ),
+                      (long)Bits.TBitSet.<Short>fromList(
+                            Flags.IEnum_Flag.it,
+                            PreludeBase.TList.DCons.<Short>mk(
+                                  Thunk.<Short>lazy(Flags.TFlag.WARNINGS),
+                                  PreludeBase.TList.DCons.<Short>mk(
+                                        Thunk.<Short>lazy(Flags.TFlag.HINTS),
+                                        PreludeBase.TList.DCons.<Short>mk(
+                                              Thunk.<Short>lazy(Flags.TFlag.VERBOSE),
+                                              PreludeBase.TList.DCons.<Short>mk(
+                                                    Thunk.<Short>lazy(Flags.TFlag.IDEMODE),
+                                                    PreludeBase.TList.DCons.<Short>mk(
+                                                          Thunk.<Short>lazy(Flags.TFlag.IDETOKENS),
+                                                          PreludeBase.TList.DList.<Short>mk()
+                                                        )
+                                                  )
+                                            )
+                                      )
+                                )
+                          ),
+                      ".", PreludeBase.TList.DList.<String/*<Character>*/>mk(), "",
+                      PreludeBase.TMaybe.DJust.<String/*<Character>*/>mk(Thunk.<String/*<Character>*/>lazy("UTF-8")),
+                      PreludeBase.TList.DList.<PreludeBase.TTuple2<Integer, Integer>>mk(), Targets.thisTarget.call(),
+                      PreludeBase.TMaybe.DNothing.<frege.compiler.types.Types.TSigmaT<QNames.TQName>>mk(),
+                      PreludeBase.TList.DList.<frege.compiler.types.Types.TSigmaT<QNames.TQName>>mk(),
+                      PreludeBase.TList.DList.<Tokens.TToken>mk()
+                    );
+          })
+    );
 final public static State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, Short> runpass(
   final PreludeBase.TTuple2<
     State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, PreludeBase.TTuple2<String/*<Character>*/, Integer>>,

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.java
@@ -406,7 +406,12 @@ final public static Lazy<Global.TOptions> standardLSPOptions = Thunk.<Global.TOp
                                                     Thunk.<Short>lazy(Flags.TFlag.IDEMODE),
                                                     PreludeBase.TList.DCons.<Short>mk(
                                                           Thunk.<Short>lazy(Flags.TFlag.IDETOKENS),
-                                                          PreludeBase.TList.DList.<Short>mk()
+                                                          PreludeBase.TList.DCons.<Short>mk(
+                                                                Thunk.<Short>lazy(Flags.TFlag.MAKE),
+                                                                PreludeBase.TList.DList.<
+                                                                  Short
+                                                                >mk()
+                                                              )
                                                         )
                                                   )
                                             )

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.java
@@ -137,7 +137,7 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.fr",
-  time=1658602829473L, jmajor=11, jminor=-1,
+  time=1658948162853L, jmajor=11, jminor=-1,
   imps={
     "frege.compiler.Classes", "ch.fhnw.thga.fregelanguageserver.compile.CompileGlobal",
     "ch.fhnw.thga.fregelanguageserver.compile.CompileOptions", "frege.compiler.common.CompilerOptions",
@@ -225,14 +225,14 @@ import frege.test.QuickCheckText;
       stri="s(u)", sig=9, depth=1, rkind=13
     ),
     @Meta.SymV(
-      offset=4809,
+      offset=4754,
       name=@Meta.QName(
         pack="ch.fhnw.thga.fregelanguageserver.compile.CompileExecutor", base="shouldCorrectlyConfigureExtraClasspath"
       ),
       stri="u", sig=10, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=4622, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.compile.CompileExecutor", base="runpass"),
+      offset=4567, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.compile.CompileExecutor", base="runpass"),
       stri="s(s(uu))", sig=12, depth=1, rkind=13
     ),
     @Meta.SymV(
@@ -255,7 +255,7 @@ import frege.test.QuickCheckText;
     ),
     @Meta.SymV(
       offset=4464, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.compile.CompileExecutor", base="compile"),
-      stri="s(us)", sig=18, depth=2, rkind=13
+      stri="s(uu)", sig=17, depth=2, rkind=13
     )
   },
   symls={},
@@ -294,14 +294,14 @@ import frege.test.QuickCheckText;
     @Meta.Rho(rhofun=false, rhotau=11), @Meta.Rho(sigma=8, rhotau=12), @Meta.Rho(rhofun=false, rhotau=14),
     @Meta.Rho(rhofun=false, rhotau=26), @Meta.Rho(rhofun=false, rhotau=28), @Meta.Rho(sigma=11, rhotau=16),
     @Meta.Rho(rhofun=false, rhotau=29), @Meta.Rho(rhofun=false, rhotau=30), @Meta.Rho(sigma=3, rhotau=19),
-    @Meta.Rho(sigma=3, rhotau=12), @Meta.Rho(rhofun=false, rhotau=31), @Meta.Rho(sigma=17, rhotau=22),
+    @Meta.Rho(sigma=3, rhotau=12), @Meta.Rho(rhofun=false, rhotau=31), @Meta.Rho(sigma=8, rhotau=22),
     @Meta.Rho(sigma=3, rhotau=23)
   },
   sigmas={
     @Meta.Sigma(rho=0), @Meta.Sigma(rho=2), @Meta.Sigma(rho=3), @Meta.Sigma(rho=1), @Meta.Sigma(rho=5),
     @Meta.Sigma(rho=6), @Meta.Sigma(rho=8), @Meta.Sigma(rho=10), @Meta.Sigma(rho=11), @Meta.Sigma(rho=13),
     @Meta.Sigma(rho=14), @Meta.Sigma(rho=15), @Meta.Sigma(rho=17), @Meta.Sigma(rho=18), @Meta.Sigma(rho=19),
-    @Meta.Sigma(rho=20), @Meta.Sigma(rho=21), @Meta.Sigma(rho=22), @Meta.Sigma(rho=24)
+    @Meta.Sigma(rho=20), @Meta.Sigma(rho=21), @Meta.Sigma(rho=24)
   },
   exprs={@Meta.Expr()}
 )
@@ -343,9 +343,9 @@ final public static class IShow_Message implements PreludeText.CShow<Global.TMes
     return "[" + (PreludeText.joined(
               Thunk.<String/*<Character>*/>lazy(", "),
               PreludeList.<String/*<Character>*/, Global.TMessage>map(
-                    (Func.U<Global.TMessage, String/*<Character>*/>)((final Lazy<Global.TMessage> η$19309) -> Thunk.<
+                    (Func.U<Global.TMessage, String/*<Character>*/>)((final Lazy<Global.TMessage> η$19325) -> Thunk.<
                           String/*<Character>*/
-                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_Message.show(η$19309.call())))),
+                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_Message.show(η$19325.call())))),
                     arg$1
                   )
             ).call() + ("]" + arg$2));
@@ -373,17 +373,17 @@ final public static class IShow_Message implements PreludeText.CShow<Global.TMes
 final public static State.TState<Global.TGlobal, Global.TGlobal> switchState(final Lazy<Global.TGlobal> arg$1) {
   return State.TState.<Global.TGlobal, Global.TGlobal>mk(
             (Func.U<Global.TGlobal, PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>>)((
-              final Lazy<Global.TGlobal> arg$19310
+              final Lazy<Global.TGlobal> arg$19326
             ) -> {
-                  final Global.TGlobal v7690$18216 = arg$19310.call();
-                  final State.TState<Global.TGlobal, Short> $19312 = State.TState.<Global.TGlobal>put(
+                  final Global.TGlobal v7690$18225 = arg$19326.call();
+                  final State.TState<Global.TGlobal, Short> $19328 = State.TState.<Global.TGlobal>put(
                         arg$1
                       );
-                  final Func.U<Global.TGlobal, PreludeBase.TTuple2<Short, Global.TGlobal>> v8822$18252 =
-                  $19312.mem$fun;
-                  final PreludeBase.TTuple2<Short, Global.TGlobal> $19314 = v8822$18252
-                  .apply(v7690$18216).call();
-                  return PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(v7690$18216, $19314.mem2);
+                  final Func.U<Global.TGlobal, PreludeBase.TTuple2<Short, Global.TGlobal>> v8822$18261 =
+                  $19328.mem$fun;
+                  final PreludeBase.TTuple2<Short, Global.TGlobal> $19330 = v8822$18261
+                  .apply(v7690$18225).call();
+                  return PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(v7690$18225, $19330.mem2);
                 })
           );
 }
@@ -395,28 +395,28 @@ final public static State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, Short> r
 ) {
   return State.TStateT.<Global.TGlobal, Func.U<RealWorld, ?>, Short>mk(
             (Func.U<Global.TGlobal, Kind.U<Func.U<RealWorld, ?>, PreludeBase.TTuple2<Short, Global.TGlobal>>>)((
-              final Lazy<Global.TGlobal> arg$19315
+              final Lazy<Global.TGlobal> arg$19331
             ) -> {
                   return Thunk.<Kind.U<Func.U<RealWorld, ?>, PreludeBase.TTuple2<Short, Global.TGlobal>>>lazy(
                             (Kind.U<Func.U<RealWorld, ?>, PreludeBase.TTuple2<Short, Global.TGlobal>>)(Func.U<
                               RealWorld, PreludeBase.TTuple2<Short, Global.TGlobal>
-                            >)((final Lazy<RealWorld> arg$19316) -> {
-                                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2056$18359 =
+                            >)((final Lazy<RealWorld> arg$19332) -> {
+                                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2056$18390 =
                                   PreludeMonad.IMonad_ST.<RealWorld, PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>>pure(
                                         PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(
-                                              arg$19315, arg$19315
+                                              arg$19331, arg$19331
                                             )
-                                      ).apply(arg$19316).call();
-                                  final Global.TGlobal v7737$18327 = v2056$18359.mem1
+                                      ).apply(arg$19332).call();
+                                  final Global.TGlobal v7737$18358 = v2056$18390.mem1
                                   .call();
                                   final State.TStateT<
                                     Global.TGlobal, Func.U<RealWorld, ?>, PreludeBase.TTuple2<String/*<Character>*/, Integer>
-                                  > $19319 = arg$1.mem1.call();
-                                  if (Global.TGlobal.errors(v7737$18327) == 0) {
+                                  > $19335 = arg$1.mem1.call();
+                                  if (Global.TGlobal.errors(v7737$18358) == 0) {
                                     final Func.U<
                                       RealWorld,
                                       PreludeBase.TTuple2<PreludeBase.TTuple2<String/*<Character>*/, Integer>, Global.TGlobal>
-                                    > v2053$18479 = RunTM.<
+                                    > v2053$18510 = RunTM.<
                                       Func.U<
                                         Global.TGlobal,
                                         Func.U<
@@ -426,33 +426,33 @@ final public static State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, Short> r
                                           >
                                         >
                                       >
-                                    >cast($19319.mem$run).apply(v2056$18359.mem2).call();
+                                    >cast($19335.mem$run).apply(v2056$18390.mem2).call();
                                     final PreludeBase.TTuple2<
                                       PreludeBase.TTuple2<String/*<Character>*/, Integer>, Global.TGlobal
-                                    > v2056$18481 = v2053$18479.apply(arg$19316).call();
-                                    final PreludeBase.TTuple2<String/*<Character>*/, Integer> v7737$18482 =
-                                    v2056$18481.mem1.call();
-                                    final Func.U<RealWorld, PreludeBase.TTuple2<Short, Global.TGlobal>> v2057$18487 =
+                                    > v2056$18512 = v2053$18510.apply(arg$19332).call();
+                                    final PreludeBase.TTuple2<String/*<Character>*/, Integer> v7737$18513 =
+                                    v2056$18512.mem1.call();
+                                    final Func.U<RealWorld, PreludeBase.TTuple2<Short, Global.TGlobal>> v2057$18518 =
                                     PreludeMonad.IMonad_ST.<RealWorld, PreludeBase.TTuple2<Short, Global.TGlobal>>pure(
                                           PreludeBase.TTuple2.<Short, Global.TGlobal>mk(
-                                                Thunk.<Short>lazy(PreludeBase.TUnit.Unit), v2056$18481.mem2
+                                                Thunk.<Short>lazy(PreludeBase.TUnit.Unit), v2056$18512.mem2
                                               )
                                         );
                                     return Thunk.<PreludeBase.TTuple2<Short, Global.TGlobal>>nested(
-                                              (Lazy<Lazy<PreludeBase.TTuple2<Short, Global.TGlobal>>>)(() -> v2057$18487
-                                                  .apply(arg$19316))
+                                              (Lazy<Lazy<PreludeBase.TTuple2<Short, Global.TGlobal>>>)(() -> v2057$18518
+                                                  .apply(arg$19332))
                                             );
                                   }
                                   else {
-                                    final Func.U<RealWorld, PreludeBase.TTuple2<Short, Global.TGlobal>> v2057$18493 =
+                                    final Func.U<RealWorld, PreludeBase.TTuple2<Short, Global.TGlobal>> v2057$18524 =
                                     PreludeMonad.IMonad_ST.<RealWorld, PreludeBase.TTuple2<Short, Global.TGlobal>>pure(
                                           PreludeBase.TTuple2.<Short, Global.TGlobal>mk(
-                                                Thunk.<Short>lazy(PreludeBase.TUnit.Unit), v2056$18359.mem2
+                                                Thunk.<Short>lazy(PreludeBase.TUnit.Unit), v2056$18390.mem2
                                               )
                                         );
                                     return Thunk.<PreludeBase.TTuple2<Short, Global.TGlobal>>nested(
-                                              (Lazy<Lazy<PreludeBase.TTuple2<Short, Global.TGlobal>>>)(() -> v2057$18493
-                                                  .apply(arg$19316))
+                                              (Lazy<Lazy<PreludeBase.TTuple2<Short, Global.TGlobal>>>)(() -> v2057$18524
+                                                  .apply(arg$19332))
                                             );
                                   }
                                 })
@@ -1566,28 +1566,28 @@ final public static Lazy<PreludeBase.TList<
 final public static State.TState<Global.TGlobal, PreludeBase.TTuple2<String/*<Character>*/, Integer>> lexPassSourceCode(
   final String/*<Character>*/ arg$1
 ) {
-  final State.TState<Global.TGlobal, PreludeBase.TList<Tokens.TToken>> $19325 = Lexer.passCS(
+  final State.TState<Global.TGlobal, PreludeBase.TList<Tokens.TToken>> $19341 = Lexer.passCS(
         (java.lang.CharSequence)(arg$1)
       );
-  final Func.U<Global.TGlobal, PreludeBase.TTuple2<PreludeBase.TList<Tokens.TToken>, Global.TGlobal>> v7688$18807 =
-  $19325.mem$fun;
+  final Func.U<Global.TGlobal, PreludeBase.TTuple2<PreludeBase.TList<Tokens.TToken>, Global.TGlobal>> v7688$18838 =
+  $19341.mem$fun;
   return State.TState.<Global.TGlobal, PreludeBase.TTuple2<String/*<Character>*/, Integer>>mk(
             (Func.U<Global.TGlobal, PreludeBase.TTuple2<PreludeBase.TTuple2<String/*<Character>*/, Integer>, Global.TGlobal>>)((
-              final Lazy<Global.TGlobal> arg$19327
+              final Lazy<Global.TGlobal> arg$19343
             ) -> {
-                  final PreludeBase.TTuple2<PreludeBase.TList<Tokens.TToken>, Global.TGlobal> $19328 =
-                  v7688$18807.apply(arg$19327).call();
-                  final PreludeBase.TTuple2<String/*<Character>*/, Integer> v7686$18836 =
+                  final PreludeBase.TTuple2<PreludeBase.TList<Tokens.TToken>, Global.TGlobal> $19344 =
+                  v7688$18838.apply(arg$19343).call();
+                  final PreludeBase.TTuple2<String/*<Character>*/, Integer> v7686$18867 =
                   PreludeBase.TTuple2.<String/*<Character>*/, Integer>mk(
                         Thunk.<String/*<Character>*/>lazy("tokens"),
                         Thunk.<Integer>shared(
                               (Lazy<Integer>)(() -> PreludeList.IListView_$lbrack$rbrack.<
                                     Tokens.TToken
-                                  >length($19328.mem1.call()))
+                                  >length($19344.mem1.call()))
                             )
                       );
                   return PreludeBase.TTuple2.<PreludeBase.TTuple2<String/*<Character>*/, Integer>, Global.TGlobal>mk(
-                            v7686$18836, $19328.mem2
+                            v7686$18867, $19344.mem2
                           );
                 })
           );
@@ -1595,84 +1595,84 @@ final public static State.TState<Global.TGlobal, PreludeBase.TTuple2<String/*<Ch
 final public static PreludeBase.TList<Tokens.TToken> ideClean(PreludeBase.TList<Tokens.TToken> arg$1) {
   tailrecursion: while (true) {
     final PreludeBase.TList<Tokens.TToken> arg$1f = arg$1;
-    final PreludeBase.TList.DCons<Tokens.TToken> $19330 = arg$1f.asCons();
-    if ($19330 != null) {
-      final Tokens.TToken t$17478 = $19330.mem1.call();
+    final PreludeBase.TList.DCons<Tokens.TToken> $19346 = arg$1f.asCons();
+    if ($19346 != null) {
+      final Tokens.TToken t$17478 = $19346.mem1.call();
       if (TokenID.IEq_TokenID.$eq$eq(Tokens.TToken.tokid(t$17478), TokenID.TTokenID.COMMENT)) {
         if (Tokens.TToken.value(t$17478).equals("}")) {
-          arg$1 = $19330.mem2.call();
+          arg$1 = $19346.mem2.call();
           continue tailrecursion;
         }
       }
       if (Tokens.TToken.col(t$17478) == 0) {
-        arg$1 = $19330.mem2.call();
+        arg$1 = $19346.mem2.call();
         continue tailrecursion;
       }
       return PreludeBase.TList.DCons.<Tokens.TToken>mk(
                 t$17478,
                 Thunk.<PreludeBase.TList<Tokens.TToken>>shared(
                       (Lazy<PreludeBase.TList<Tokens.TToken>>)(() -> CompileExecutor.ideClean(
-                                $19330.mem2.call()
+                                $19346.mem2.call()
                               ))
                     )
               );
     }
-    final PreludeBase.TList.DList<Tokens.TToken> $19332 = arg$1f.asList();
-    assert $19332 != null;
+    final PreludeBase.TList.DList<Tokens.TToken> $19348 = arg$1f.asList();
+    assert $19348 != null;
     return PreludeBase.TList.DList.<Tokens.TToken>mk();
   }
 }
 final public static State.TState<Global.TGlobal, PreludeBase.TTuple2<String/*<Character>*/, Integer>> parsePass =
 State.TState.<Global.TGlobal, PreludeBase.TTuple2<String/*<Character>*/, Integer>>mk(
       (Func.U<Global.TGlobal, PreludeBase.TTuple2<PreludeBase.TTuple2<String/*<Character>*/, Integer>, Global.TGlobal>>)((
-        final Lazy<Global.TGlobal> arg$19333
+        final Lazy<Global.TGlobal> arg$19349
       ) -> {
-            final State.TState<Global.TGlobal, PreludeBase.TMaybe<Desugar.TProgram>> $19335 =
+            final State.TState<Global.TGlobal, PreludeBase.TMaybe<Desugar.TProgram>> $19351 =
             Frege.pass(
                   Thunk.<PreludeBase.TList<Tokens.TToken>>shared(
                         (Lazy<PreludeBase.TList<Tokens.TToken>>)(() -> PreludeList.<Tokens.TToken>filter(
-                                  (Func.U<Tokens.TToken, Boolean>)((final Lazy<Tokens.TToken> η$19334) -> Thunk.<
+                                  (Func.U<Tokens.TToken, Boolean>)((final Lazy<Tokens.TToken> η$19350) -> Thunk.<
                                         Boolean
-                                      >shared((Lazy<Boolean>)(() -> Tokens.TToken.noComment(η$19334.call())))),
+                                      >shared((Lazy<Boolean>)(() -> Tokens.TToken.noComment(η$19350.call())))),
                                   PreludeArrays.IListSource_JArray.<Tokens.TToken>toList(
-                                        Global.TSubSt.toks(Global.TGlobal.sub(arg$19333.call()))
+                                        Global.TSubSt.toks(Global.TGlobal.sub(arg$19349.call()))
                                       )
                                 ))
                       )
                 );
             final Func.U<
               Global.TGlobal, PreludeBase.TTuple2<PreludeBase.TMaybe<Desugar.TProgram>, Global.TGlobal>
-            > v7688$18614 = $19335.mem$fun;
-            final PreludeBase.TTuple2<PreludeBase.TMaybe<Desugar.TProgram>, Global.TGlobal> $19337 =
-            v7688$18614.apply(arg$19333).call();
-            final PreludeBase.TMaybe<Desugar.TProgram> v7691$18617 = $19337.mem1.call();
-            final PreludeBase.TMaybe.DJust<Desugar.TProgram> $19339 = v7691$18617.asJust();
-            if ($19339 != null) {
-              final Desugar.TProgram $19340 = $19339.mem1.call();
-              final Desugar.TProgram.DModule $19341 = $19340.asModule();
-              if ($19341 != null) {
+            > v7688$18645 = $19351.mem$fun;
+            final PreludeBase.TTuple2<PreludeBase.TMaybe<Desugar.TProgram>, Global.TGlobal> $19353 =
+            v7688$18645.apply(arg$19349).call();
+            final PreludeBase.TMaybe<Desugar.TProgram> v7691$18648 = $19353.mem1.call();
+            final PreludeBase.TMaybe.DJust<Desugar.TProgram> $19355 = v7691$18648.asJust();
+            if ($19355 != null) {
+              final Desugar.TProgram $19356 = $19355.mem1.call();
+              final Desugar.TProgram.DModule $19357 = $19356.asModule();
+              if ($19357 != null) {
                 final PreludeBase.TTuple3<
                   String/*<Character>*/, PreludeBase.TList<SourceDefinitions.TDefinitionS>,
                   PreludeBase.TMaybe<String/*<Character>*/>
-                > $19342 = $19341.mem1.call();
-                final PreludeBase.TTuple2<String/*<Character>*/, Integer> v16081$18771 =
+                > $19358 = $19357.mem1.call();
+                final PreludeBase.TTuple2<String/*<Character>*/, Integer> v16081$18802 =
                 PreludeBase.TTuple2.<String/*<Character>*/, Integer>mk(
                       Thunk.<String/*<Character>*/>lazy("tokens"),
                       Thunk.<Integer>shared(
                             (Lazy<Integer>)(() -> java.lang.reflect.Array.getLength(
-                                      Global.TSubSt.toks(Global.TGlobal.sub(arg$19333.call()))
+                                      Global.TSubSt.toks(Global.TGlobal.sub(arg$19349.call()))
                                     ))
                           )
                     );
-                final Lazy<State.TState<Global.TGlobal, Short>> tmp$18796 = Thunk.<State.TState<Global.TGlobal, Short>>shared(
+                final Lazy<State.TState<Global.TGlobal, Short>> tmp$18827 = Thunk.<State.TState<Global.TGlobal, Short>>shared(
                       (Lazy<State.TState<Global.TGlobal, Short>>)(() -> {
                             if (
                               Flags.isOn(
-                                    (long)Global.TOptions.flags(Global.TGlobal.options(arg$19333.call())), Flags.TFlag.IDETOKENS
+                                    (long)Global.TOptions.flags(Global.TGlobal.options(arg$19349.call())), Flags.TFlag.IDETOKENS
                                   )
                             ) {
                               return State.TState.<Global.TGlobal>modify(
-                                        (Func.U<Global.TGlobal, Global.TGlobal>)((final Lazy<Global.TGlobal> η$19344) -> Thunk.<
+                                        (Func.U<Global.TGlobal, Global.TGlobal>)((final Lazy<Global.TGlobal> η$19360) -> Thunk.<
                                               Global.TGlobal
                                             >nested(
                                                   (Lazy<Lazy<Global.TGlobal>>)(() -> PreludeBase.<
@@ -1681,17 +1681,17 @@ State.TState.<Global.TGlobal, PreludeBase.TTuple2<String/*<Character>*/, Integer
                                                             (Func.U<
                                                               Global.TGlobal,
                                                               Func.U<Func.U<Global.TSubSt, Global.TSubSt>, Global.TGlobal>
-                                                            >)((final Lazy<Global.TGlobal> η$19345) -> (Func.U<
+                                                            >)((final Lazy<Global.TGlobal> η$19361) -> (Func.U<
                                                                   Func.U<Global.TSubSt, Global.TSubSt>, Global.TGlobal
                                                                 >)((
-                                                                  final Lazy<Func.U<Global.TSubSt, Global.TSubSt>> η$19346
+                                                                  final Lazy<Func.U<Global.TSubSt, Global.TSubSt>> η$19362
                                                                 ) -> Thunk.<Global.TGlobal>shared(
                                                                           (Lazy<Global.TGlobal>)(() -> Global.TGlobal.chg$sub(
-                                                                                    η$19345.call(), η$19346.call()
+                                                                                    η$19361.call(), η$19362.call()
                                                                                   ))
                                                                         ))),
                                                             (Func.U<Global.TSubSt, Global.TSubSt>)((
-                                                              final Lazy<Global.TSubSt> η$19347
+                                                              final Lazy<Global.TSubSt> η$19363
                                                             ) -> Thunk.<Global.TSubSt>nested(
                                                                       (Lazy<Lazy<Global.TSubSt>>)(() -> PreludeBase.<
                                                                             Global.TSubSt, Global.TSubSt,
@@ -1707,7 +1707,7 @@ State.TState.<Global.TGlobal, PreludeBase.TTuple2<String/*<Character>*/, Integer
                                                                                     Global.TSubSt
                                                                                   >
                                                                                 >)((
-                                                                                  final Lazy<Global.TSubSt> η$19348
+                                                                                  final Lazy<Global.TSubSt> η$19364
                                                                                 ) -> (Func.U<
                                                                                       Func.U<
                                                                                         Tokens.TToken[],
@@ -1718,37 +1718,37 @@ State.TState.<Global.TGlobal, PreludeBase.TTuple2<String/*<Character>*/, Integer
                                                                                       final Lazy<Func.U<
                                                                                         Tokens.TToken[],
                                                                                         Tokens.TToken[]
-                                                                                      >> η$19349
+                                                                                      >> η$19365
                                                                                     ) -> Thunk.<
                                                                                           Global.TSubSt
                                                                                         >shared(
                                                                                               (Lazy<Global.TSubSt>)(() -> Global.TSubSt.chg$toks(
-                                                                                                        η$19348
+                                                                                                        η$19364
                                                                                                         .call(),
-                                                                                                        η$19349
+                                                                                                        η$19365
                                                                                                         .call()
                                                                                                       ))
                                                                                             ))),
                                                                                 (Func.U<
                                                                                   Tokens.TToken[], Tokens.TToken[]
-                                                                                >)((final Lazy<Tokens.TToken[]> arg$19350) -> {
-                                                                                      final Tokens.TToken[] v2338$18749 =
-                                                                                      arg$19350
+                                                                                >)((final Lazy<Tokens.TToken[]> arg$19366) -> {
+                                                                                      final Tokens.TToken[] v2338$18780 =
+                                                                                      arg$19366
                                                                                       .call();
                                                                                       return Tokens.IArrayElement_Token.arrayFromList(
                                                                                                 CompileExecutor.ideClean(
                                                                                                       PreludeArrays.IListSource_JArray.<
                                                                                                         Tokens.TToken
                                                                                                       >toList(
-                                                                                                            v2338$18749
+                                                                                                            v2338$18780
                                                                                                           )
                                                                                                     )
                                                                                               );
                                                                                     }),
-                                                                                η$19347
+                                                                                η$19363
                                                                               ))
                                                                     )),
-                                                            η$19344
+                                                            η$19360
                                                           ))
                                                 ))
                                       );
@@ -1756,21 +1756,21 @@ State.TState.<Global.TGlobal, PreludeBase.TTuple2<String/*<Character>*/, Integer
                             else {
                               return State.TState.<Global.TGlobal, Short>mk(
                                         (Func.U<Global.TGlobal, PreludeBase.TTuple2<Short, Global.TGlobal>>)((
-                                          final Lazy<Global.TGlobal> arg$19352
+                                          final Lazy<Global.TGlobal> arg$19368
                                         ) -> {
                                               return PreludeBase.TTuple2.<Short, Global.TGlobal>mk(
-                                                        Thunk.<Short>lazy(PreludeBase.TUnit.Unit), arg$19352
+                                                        Thunk.<Short>lazy(PreludeBase.TUnit.Unit), arg$19368
                                                       );
                                             })
                                       );
                             }
                           })
                     );
-                final State.TState<Global.TGlobal, Short> $19353 = tmp$18796.call();
-                final Func.U<Global.TGlobal, PreludeBase.TTuple2<Short, Global.TGlobal>> v8822$18701 =
-                $19353.mem$fun;
-                final State.TState<Global.TGlobal, Short> $19365 = State.TState.<Global.TGlobal>modify(
-                      (Func.U<Global.TGlobal, Global.TGlobal>)((final Lazy<Global.TGlobal> η$19355) -> Thunk.<
+                final State.TState<Global.TGlobal, Short> $19369 = tmp$18827.call();
+                final Func.U<Global.TGlobal, PreludeBase.TTuple2<Short, Global.TGlobal>> v8822$18732 =
+                $19369.mem$fun;
+                final State.TState<Global.TGlobal, Short> $19381 = State.TState.<Global.TGlobal>modify(
+                      (Func.U<Global.TGlobal, Global.TGlobal>)((final Lazy<Global.TGlobal> η$19371) -> Thunk.<
                             Global.TGlobal
                           >nested(
                                 (Lazy<Lazy<Global.TGlobal>>)(() -> PreludeBase.<
@@ -1778,31 +1778,31 @@ State.TState.<Global.TGlobal, PreludeBase.TTuple2<String/*<Character>*/, Integer
                                     >flip(
                                           (Func.U<
                                             Global.TGlobal, Func.U<Func.U<Global.TSubSt, Global.TSubSt>, Global.TGlobal>
-                                          >)((final Lazy<Global.TGlobal> η$19356) -> (Func.U<
+                                          >)((final Lazy<Global.TGlobal> η$19372) -> (Func.U<
                                                 Func.U<Global.TSubSt, Global.TSubSt>, Global.TGlobal
-                                              >)((final Lazy<Func.U<Global.TSubSt, Global.TSubSt>> η$19357) -> Thunk.<
+                                              >)((final Lazy<Func.U<Global.TSubSt, Global.TSubSt>> η$19373) -> Thunk.<
                                                     Global.TGlobal
                                                   >shared(
                                                         (Lazy<Global.TGlobal>)(() -> Global.TGlobal.chg$sub(
-                                                                  η$19356.call(), η$19357.call()
+                                                                  η$19372.call(), η$19373.call()
                                                                 ))
                                                       ))),
-                                          (Func.U<Global.TSubSt, Global.TSubSt>)((final Lazy<Global.TSubSt> arg$19358) -> {
+                                          (Func.U<Global.TSubSt, Global.TSubSt>)((final Lazy<Global.TSubSt> arg$19374) -> {
                                                 return PreludeBase.<Global.TSubSt, Global.TSubSt, String/*<Character>*/>flip(
                                                           (Func.U<
                                                             Global.TSubSt, Func.U<String/*<Character>*/, Global.TSubSt>
-                                                          >)((final Lazy<Global.TSubSt> η$19359) -> (Func.U<
+                                                          >)((final Lazy<Global.TSubSt> η$19375) -> (Func.U<
                                                                 String/*<Character>*/, Global.TSubSt
-                                                              >)((final Lazy<String/*<Character>*/> η$19360) -> Thunk.<
+                                                              >)((final Lazy<String/*<Character>*/> η$19376) -> Thunk.<
                                                                     Global.TSubSt
                                                                   >shared(
                                                                         (Lazy<Global.TSubSt>)(() -> Global.TSubSt.upd$thisPack(
-                                                                                  η$19359.call(), η$19360.call()
+                                                                                  η$19375.call(), η$19376.call()
                                                                                 ))
                                                                       ))),
                                                           Thunk.<String/*<Character>*/>shared(
                                                                 (Lazy<String/*<Character>*/>)(() -> Packs.TPack.$new(
-                                                                          $19342.mem1
+                                                                          $19358.mem1
                                                                         ))
                                                               ),
                                                           Thunk.<Global.TSubSt>nested(
@@ -1820,7 +1820,7 @@ State.TState.<Global.TGlobal, PreludeBase.TTuple2<String/*<Character>*/, Integer
                                                                               >,
                                                                               Global.TSubSt
                                                                             >
-                                                                          >)((final Lazy<Global.TSubSt> η$19361) -> (Func.U<
+                                                                          >)((final Lazy<Global.TSubSt> η$19377) -> (Func.U<
                                                                                 PreludeBase.TList<
                                                                                   SourceDefinitions.TDefinitionS
                                                                                 >,
@@ -1828,18 +1828,18 @@ State.TState.<Global.TGlobal, PreludeBase.TTuple2<String/*<Character>*/, Integer
                                                                               >)((
                                                                                 final Lazy<PreludeBase.TList<
                                                                                   SourceDefinitions.TDefinitionS
-                                                                                >> η$19362
+                                                                                >> η$19378
                                                                               ) -> Thunk.<
                                                                                     Global.TSubSt
                                                                                   >shared(
                                                                                         (Lazy<Global.TSubSt>)(() -> Global.TSubSt.upd$sourcedefs(
-                                                                                                  η$19361
+                                                                                                  η$19377
                                                                                                   .call(),
-                                                                                                  η$19362
+                                                                                                  η$19378
                                                                                                   .call()
                                                                                                 ))
                                                                                       ))),
-                                                                          $19342.mem2,
+                                                                          $19358.mem2,
                                                                           Thunk.<Global.TSubSt>nested(
                                                                                 (Lazy<Lazy<Global.TSubSt>>)(() -> PreludeBase.<
                                                                                       Global.TSubSt,
@@ -1865,7 +1865,7 @@ State.TState.<Global.TGlobal, PreludeBase.TTuple2<String/*<Character>*/, Integer
                                                                                               Global.TSubSt
                                                                                             >
                                                                                           >)((
-                                                                                            final Lazy<Global.TSubSt> η$19363
+                                                                                            final Lazy<Global.TSubSt> η$19379
                                                                                           ) -> (Func.U<
                                                                                                 PreludeBase.TMaybe<
                                                                                                   String/*
@@ -1882,102 +1882,102 @@ State.TState.<Global.TGlobal, PreludeBase.TTuple2<String/*<Character>*/, Integer
                                                                                                       Character
                                                                                                     >
                                                                                                   */
-                                                                                                >> η$19364
+                                                                                                >> η$19380
                                                                                               ) -> Thunk.<
                                                                                                     Global.TSubSt
                                                                                                   >shared(
                                                                                                         (Lazy<Global.TSubSt>)(() -> Global.TSubSt.upd$packageDoc(
-                                                                                                                  η$19363
+                                                                                                                  η$19379
                                                                                                                   .call(),
-                                                                                                                  η$19364
+                                                                                                                  η$19380
                                                                                                                   .call()
                                                                                                                 ))
                                                                                                       ))),
-                                                                                          $19342.mem3,
-                                                                                          arg$19358
+                                                                                          $19358.mem3,
+                                                                                          arg$19374
                                                                                         ))
                                                                               )
                                                                         ))
                                                               )
                                                         );
                                               }),
-                                          η$19355
+                                          η$19371
                                         ))
                               ))
                     );
-                final Func.U<Global.TGlobal, PreludeBase.TTuple2<Short, Global.TGlobal>> v8822$18643 =
-                $19365.mem$fun;
-                final PreludeBase.TTuple2<Short, Global.TGlobal> $19367 = v8822$18643
-                .apply($19337.mem2).call();
-                final PreludeBase.TTuple2<Short, Global.TGlobal> $19368 = v8822$18701
-                .apply($19367.mem2).call();
+                final Func.U<Global.TGlobal, PreludeBase.TTuple2<Short, Global.TGlobal>> v8822$18674 =
+                $19381.mem$fun;
+                final PreludeBase.TTuple2<Short, Global.TGlobal> $19383 = v8822$18674
+                .apply($19353.mem2).call();
+                final PreludeBase.TTuple2<Short, Global.TGlobal> $19384 = v8822$18732
+                .apply($19383.mem2).call();
                 return PreludeBase.TTuple2.<PreludeBase.TTuple2<String/*<Character>*/, Integer>, Global.TGlobal>mk(
-                          v16081$18771, $19368.mem2
+                          v16081$18802, $19384.mem2
                         );
               }
             }
-            final PreludeBase.TTuple2<String/*<Character>*/, Integer> v16081$18797 = PreludeBase.TTuple2.<
+            final PreludeBase.TTuple2<String/*<Character>*/, Integer> v16081$18828 = PreludeBase.TTuple2.<
               String/*<Character>*/, Integer
             >mk(
                   Thunk.<String/*<Character>*/>lazy("tokens"),
                   Thunk.<Integer>shared(
                         (Lazy<Integer>)(() -> java.lang.reflect.Array.getLength(
-                                  Global.TSubSt.toks(Global.TGlobal.sub(arg$19333.call()))
+                                  Global.TSubSt.toks(Global.TGlobal.sub(arg$19349.call()))
                                 ))
                       )
                 );
             return PreludeBase.TTuple2.<PreludeBase.TTuple2<String/*<Character>*/, Integer>, Global.TGlobal>mk(
-                      v16081$18797, $19337.mem2
+                      v16081$18828, $19353.mem2
                     );
           })
     );
 final public static State.TState<Global.TGlobal, Global.TGlobal> lexParseSourceCode(final String/*<Character>*/ arg$1) {
   return State.TState.<Global.TGlobal, Global.TGlobal>mk(
             (Func.U<Global.TGlobal, PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>>)((
-              final Lazy<Global.TGlobal> arg$19370
+              final Lazy<Global.TGlobal> arg$19386
             ) -> {
-                  final State.TState<Global.TGlobal, Global.TGlobal> $19371 = CompileExecutor.switchState(
-                        arg$19370
+                  final State.TState<Global.TGlobal, Global.TGlobal> $19387 = CompileExecutor.switchState(
+                        arg$19386
                       );
-                  final Func.U<Global.TGlobal, PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>> v7688$18942 =
-                  $19371.mem$fun;
+                  final Func.U<Global.TGlobal, PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>> v7688$18973 =
+                  $19387.mem$fun;
                   final Func.U<
                     Global.TGlobal, PreludeBase.TTuple2<PreludeBase.TTuple2<String/*<Character>*/, Integer>, Global.TGlobal>
-                  > v8822$18917 = CompileExecutor.parsePass.mem$fun;
-                  final State.TState<Global.TGlobal, PreludeBase.TTuple2<String/*<Character>*/, Integer>> $19374 =
+                  > v8822$18948 = CompileExecutor.parsePass.mem$fun;
+                  final State.TState<Global.TGlobal, PreludeBase.TTuple2<String/*<Character>*/, Integer>> $19390 =
                   CompileExecutor.lexPassSourceCode(arg$1);
                   final Func.U<
                     Global.TGlobal, PreludeBase.TTuple2<PreludeBase.TTuple2<String/*<Character>*/, Integer>, Global.TGlobal>
-                  > v8822$18889 = $19374.mem$fun;
-                  final PreludeBase.TTuple2<PreludeBase.TTuple2<String/*<Character>*/, Integer>, Global.TGlobal> $19376 =
-                  v8822$18889.apply(arg$19370).call();
-                  final PreludeBase.TTuple2<PreludeBase.TTuple2<String/*<Character>*/, Integer>, Global.TGlobal> $19377 =
-                  v8822$18917.apply($19376.mem2).call();
-                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> $19378 = v7688$18942
-                  .apply($19377.mem2).call();
-                  final Global.TGlobal v7691$18945 = $19378.mem1.call();
-                  final State.TState<Global.TGlobal, Short> $19385 = State.TState.<Global.TGlobal>modify(
-                        (Func.U<Global.TGlobal, Global.TGlobal>)((final Lazy<Global.TGlobal> arg$19380) -> {
-                              final Global.TGlobal in$17472 = arg$19380.call();
+                  > v8822$18920 = $19390.mem$fun;
+                  final PreludeBase.TTuple2<PreludeBase.TTuple2<String/*<Character>*/, Integer>, Global.TGlobal> $19392 =
+                  v8822$18920.apply(arg$19386).call();
+                  final PreludeBase.TTuple2<PreludeBase.TTuple2<String/*<Character>*/, Integer>, Global.TGlobal> $19393 =
+                  v8822$18948.apply($19392.mem2).call();
+                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> $19394 = v7688$18973
+                  .apply($19393.mem2).call();
+                  final Global.TGlobal v7691$18976 = $19394.mem1.call();
+                  final State.TState<Global.TGlobal, Short> $19401 = State.TState.<Global.TGlobal>modify(
+                        (Func.U<Global.TGlobal, Global.TGlobal>)((final Lazy<Global.TGlobal> arg$19396) -> {
+                              final Global.TGlobal in$17472 = arg$19396.call();
                               return Thunk.<Global.TGlobal>shared(
                                         (Lazy<Global.TGlobal>)(() -> Global.TGlobal.chg$sub(
                                                   in$17472,
                                                   (Func.U<Global.TSubSt, Global.TSubSt>)((
-                                                    final Lazy<Global.TSubSt> arg$19382
+                                                    final Lazy<Global.TSubSt> arg$19398
                                                   ) -> {
                                                         final Global.TSubSt in$17473 =
-                                                        arg$19382.call();
+                                                        arg$19398.call();
                                                         return Thunk.<Global.TSubSt>shared(
                                                                   (Lazy<Global.TSubSt>)(() -> Global.TSubSt.chg$numErrors(
                                                                             in$17473,
                                                                             (Func.U<Integer, Integer>)((
-                                                                              final Lazy<Integer> η$19384
+                                                                              final Lazy<Integer> η$19400
                                                                             ) -> Thunk.<
                                                                                   Integer
                                                                                 >shared(
                                                                                       (Lazy<Integer>)(() -> Global.TGlobal.errors(
-                                                                                                v7691$18945
-                                                                                              ) + (int)η$19384
+                                                                                                v7691$18976
+                                                                                              ) + (int)η$19400
                                                                                           .call())
                                                                                     ))
                                                                           ))
@@ -1987,18 +1987,18 @@ final public static State.TState<Global.TGlobal, Global.TGlobal> lexParseSourceC
                                       );
                             })
                       );
-                  final Func.U<Global.TGlobal, PreludeBase.TTuple2<Short, Global.TGlobal>> v8822$18971 =
-                  $19385.mem$fun;
-                  final PreludeBase.TTuple2<Short, Global.TGlobal> $19387 = v8822$18971
-                  .apply($19378.mem2).call();
-                  return PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(v7691$18945, $19387.mem2);
+                  final Func.U<Global.TGlobal, PreludeBase.TTuple2<Short, Global.TGlobal>> v8822$19002 =
+                  $19401.mem$fun;
+                  final PreludeBase.TTuple2<Short, Global.TGlobal> $19403 = v8822$19002
+                  .apply($19394.mem2).call();
+                  return PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(v7691$18976, $19403.mem2);
                 })
           );
 }
 final public static State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, Global.TGlobal> compileSourceCode(
   final Lazy<String/*<Character>*/> arg$1
 ) {
-  final State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, Global.TGlobal> $19388 = Global.<
+  final State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, Global.TGlobal> $19404 = Global.<
     Global.TGlobal
   >liftStG(
         Thunk.<State.TState<Global.TGlobal, Global.TGlobal>>shared(
@@ -2007,24 +2007,24 @@ final public static State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, Global.T
                       ))
             )
       );
-  final Func.U<Global.TGlobal, Kind.U<Func.U<RealWorld, ?>, PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>>> v7734$19035 =
-  $19388.mem$run;
+  final Func.U<Global.TGlobal, Kind.U<Func.U<RealWorld, ?>, PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>>> v7734$19051 =
+  $19404.mem$run;
   return State.TStateT.<Global.TGlobal, Func.U<RealWorld, ?>, Global.TGlobal>mk(
             (Func.U<Global.TGlobal, Kind.U<Func.U<RealWorld, ?>, PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>>>)((
-              final Lazy<Global.TGlobal> arg$19390
+              final Lazy<Global.TGlobal> arg$19406
             ) -> {
                   return Thunk.<Kind.U<Func.U<RealWorld, ?>, PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>>>lazy(
                             (Kind.U<Func.U<RealWorld, ?>, PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>>)(Func.U<
                               RealWorld, PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>
-                            >)((final Lazy<RealWorld> arg$19391) -> {
-                                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2056$19070 =
+                            >)((final Lazy<RealWorld> arg$19407) -> {
+                                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2056$19086 =
                                   RunTM.<
                                     Func.U<
                                       Global.TGlobal, Func.U<RealWorld, PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>>
                                     >
-                                  >cast(v7734$19035).apply(arg$19390).call().apply(arg$19391)
+                                  >cast(v7734$19051).apply(arg$19406).call().apply(arg$19407)
                                   .call();
-                                  final State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, Short> $19394 =
+                                  final State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, Short> $19410 =
                                   Global.<
                                     PreludeBase.TTuple2<
                                       State.TStateT<
@@ -2052,54 +2052,54 @@ final public static State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, Global.T
                                               PreludeBase.TTuple2<String/*<Character>*/, Integer>
                                             >,
                                             String/*<Character>*/
-                                          >> η$19393
+                                          >> η$19409
                                         ) -> Thunk.<State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, Short>>shared(
                                                   (Lazy<State.TStateT<
                                                     Global.TGlobal, Func.U<RealWorld, ?>, Short
-                                                  >>)(() -> CompileExecutor.runpass(η$19393.call()))
+                                                  >>)(() -> CompileExecutor.runpass(η$19409.call()))
                                                 ))
                                       );
                                   final Func.U<
                                     Global.TGlobal, Kind.U<Func.U<RealWorld, ?>, PreludeBase.TTuple2<Short, Global.TGlobal>>
-                                  > v8728$19157 = $19394.mem$run;
-                                  final State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, Short> $19396 =
+                                  > v8728$19173 = $19410.mem$run;
+                                  final State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, Short> $19412 =
                                   State.TStateT.<Global.TGlobal, Func.U<RealWorld, ?>>put(
-                                        PreludeMonad.IMonad_ST.<RealWorld>mk(), v2056$19070.mem1
+                                        PreludeMonad.IMonad_ST.<RealWorld>mk(), v2056$19086.mem1
                                       );
                                   final Func.U<
                                     Global.TGlobal, Kind.U<Func.U<RealWorld, ?>, PreludeBase.TTuple2<Short, Global.TGlobal>>
-                                  > v8728$19100 = $19396.mem$run;
-                                  final Func.U<RealWorld, PreludeBase.TTuple2<Short, Global.TGlobal>> v2053$19131 =
+                                  > v8728$19116 = $19412.mem$run;
+                                  final Func.U<RealWorld, PreludeBase.TTuple2<Short, Global.TGlobal>> v2053$19147 =
                                   RunTM.<
                                     Func.U<Global.TGlobal, Func.U<RealWorld, PreludeBase.TTuple2<Short, Global.TGlobal>>>
-                                  >cast(v8728$19100).apply(v2056$19070.mem2).call();
-                                  final PreludeBase.TTuple2<Short, Global.TGlobal> v2056$19134 =
-                                  v2053$19131.apply(arg$19391).call();
-                                  final Func.U<RealWorld, PreludeBase.TTuple2<Short, Global.TGlobal>> v2053$19188 =
+                                  >cast(v8728$19116).apply(v2056$19086.mem2).call();
+                                  final PreludeBase.TTuple2<Short, Global.TGlobal> v2056$19150 =
+                                  v2053$19147.apply(arg$19407).call();
+                                  final Func.U<RealWorld, PreludeBase.TTuple2<Short, Global.TGlobal>> v2053$19204 =
                                   RunTM.<
                                     Func.U<Global.TGlobal, Func.U<RealWorld, PreludeBase.TTuple2<Short, Global.TGlobal>>>
-                                  >cast(v8728$19157).apply(v2056$19134.mem2).call();
-                                  final PreludeBase.TTuple2<Short, Global.TGlobal> v2056$19191 =
-                                  v2053$19188.apply(arg$19391).call();
-                                  final Func.U<RealWorld, PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>> v2053$19243 =
+                                  >cast(v8728$19173).apply(v2056$19150.mem2).call();
+                                  final PreludeBase.TTuple2<Short, Global.TGlobal> v2056$19207 =
+                                  v2053$19204.apply(arg$19407).call();
+                                  final Func.U<RealWorld, PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>> v2053$19259 =
                                   PreludeMonad.IMonad_ST.<RealWorld, PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>>pure(
                                         PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(
-                                              v2056$19191.mem2, v2056$19191.mem2
+                                              v2056$19207.mem2, v2056$19207.mem2
                                             )
                                       );
-                                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2056$19246 =
-                                  v2053$19243.apply(arg$19391).call();
-                                  final Global.TGlobal v7737$19214 = v2056$19246.mem1
+                                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2056$19262 =
+                                  v2053$19259.apply(arg$19407).call();
+                                  final Global.TGlobal v7737$19230 = v2056$19262.mem1
                                   .call();
-                                  final Func.U<RealWorld, PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>> v2057$19247 =
+                                  final Func.U<RealWorld, PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>> v2057$19263 =
                                   PreludeMonad.IMonad_ST.<RealWorld, PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>>pure(
                                         PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(
-                                              v7737$19214, v2056$19246.mem2
+                                              v7737$19230, v2056$19262.mem2
                                             )
                                       );
                                   return Thunk.<PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>>nested(
-                                            (Lazy<Lazy<PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>>>)(() -> v2057$19247
-                                                .apply(arg$19391))
+                                            (Lazy<Lazy<PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal>>>)(() -> v2057$19263
+                                                .apply(arg$19407))
                                           );
                                 })
                           );
@@ -2107,23 +2107,19 @@ final public static State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, Global.T
           );
 }
 final public static Func.U<RealWorld, Global.TGlobal> compile(
-  final Lazy<String/*<Character>*/> arg$1, final Func.U<RealWorld, Global.TGlobal> arg$2
+  final Lazy<String/*<Character>*/> arg$1, final Lazy<Global.TGlobal> arg$2
 ) {
-  return (Func.U<RealWorld, Global.TGlobal>)((final Lazy<RealWorld> arg$19406) -> {
-            final Global.TGlobal v2056$19015 = arg$2.apply(arg$19406).call();
-            final Func.U<RealWorld, Global.TGlobal> v2057$19016 = Func.<RealWorld, Global.TGlobal>coerceU(
-                  State.<Global.TGlobal, Func.U<RealWorld, ?>, Global.TGlobal>execStateT(
-                        PreludeMonad.IMonad_ST.<RealWorld>mk(),
-                        Thunk.<State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, Global.TGlobal>>shared(
-                              (Lazy<State.TStateT<
-                                Global.TGlobal, Func.U<RealWorld, ?>, Global.TGlobal
-                              >>)(() -> CompileExecutor.compileSourceCode(arg$1))
-                            ),
-                        v2056$19015
-                      )
-                );
-            return Thunk.<Global.TGlobal>nested((Lazy<Lazy<Global.TGlobal>>)(() -> v2057$19016.apply(arg$19406)));
-          });
+  return Func.<RealWorld, Global.TGlobal>coerceU(
+            State.<Global.TGlobal, Func.U<RealWorld, ?>, Global.TGlobal>execStateT(
+                  PreludeMonad.IMonad_ST.<RealWorld>mk(),
+                  Thunk.<State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, Global.TGlobal>>shared(
+                        (Lazy<State.TStateT<
+                          Global.TGlobal, Func.U<RealWorld, ?>, Global.TGlobal
+                        >>)(() -> CompileExecutor.compileSourceCode(arg$1))
+                      ),
+                  arg$2
+                )
+          );
 }
 final public static Lazy<QuickCheckGen.TGen<
   QuickCheckProperty.TRose<QuickCheckProperty.TResult>
@@ -2140,41 +2136,43 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$19409) -> {
-                                            final Global.TGlobal v2056$18297 = CompileExecutor.compile(
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$19422) -> {
+                                            final Global.TGlobal v2056$18306 = CompileGlobal.fromOptions(
+                                                  Global.TOptions.upd$path(
+                                                        CompileOptions.standardCompileOptions
+                                                        .call(),
+                                                        PreludeBase.TList.DCons.<String/*<Character>*/>mk(
+                                                              Thunk.<String/*<Character>*/>lazy(
+                                                                    "./src/main/resources/fregefx-0.8.2-SNAPSHOT.jar"
+                                                                  ),
+                                                              PreludeBase.TList.DList.<
+                                                                String/*<Character>*/
+                                                              >mk()
+                                                            )
+                                                      )
+                                                ).apply(arg$19422).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$18325 =
+                                            CompileExecutor.compile(
                                                   Thunk.<String/*<Character>*/>shared(
                                                         (Lazy<String/*
                                                           <Character>
                                                         */>)(() -> "module FregeFxDep where\n\n" + ("import fregefx.JavaFxType\n\n" + "main = println \"Hello FregeFX\""))
                                                       ),
-                                                  CompileGlobal.fromOptions(
-                                                        Global.TOptions.upd$path(
-                                                              CompileOptions.standardCompileOptions
-                                                              .call(),
-                                                              PreludeBase.TList.DCons.<
-                                                                String/*<Character>*/
-                                                              >mk(
-                                                                    Thunk.<String/*<Character>*/>lazy(
-                                                                          "./src/main/resources/fregefx-0.8.2-SNAPSHOT.jar"
-                                                                        ),
-                                                                    PreludeBase.TList.DList.<
-                                                                      String/*<Character>*/
-                                                                    >mk()
-                                                                  )
-                                                            )
-                                                      )
-                                                ).apply(arg$19409).call();
-                                            final Func.U<RealWorld, Boolean> v2057$18298 =
+                                                  v2056$18306
+                                                );
+                                            final Global.TGlobal v2056$18328 = v2053$18325
+                                            .apply(arg$19422).call();
+                                            final Func.U<RealWorld, Boolean> v2057$18329 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Global.TGlobal.errors(
-                                                                  v2056$18297
+                                                                  v2056$18328
                                                                 ) == 0)
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18298
-                                                          .apply(arg$19409))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18329
+                                                          .apply(arg$19422))
                                                     );
                                           })
                                     ))

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.java
@@ -137,7 +137,7 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.fr",
-  time=1658516065400L, jmajor=11, jminor=-1,
+  time=1658602829473L, jmajor=11, jminor=-1,
   imps={
     "frege.compiler.Classes", "ch.fhnw.thga.fregelanguageserver.compile.CompileGlobal",
     "ch.fhnw.thga.fregelanguageserver.compile.CompileOptions", "frege.compiler.common.CompilerOptions",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.java
@@ -387,46 +387,6 @@ final public static State.TState<Global.TGlobal, Global.TGlobal> switchState(fin
                 })
           );
 }
-final public static Lazy<Global.TOptions> standardLSPOptions = Thunk.<Global.TOptions>shared(
-      (Lazy<Global.TOptions>)(() -> {
-            return Global.TOptions.mk(
-                      "-",
-                      PreludeBase.TList.DCons.<String/*<Character>*/>mk(
-                            Thunk.<String/*<Character>*/>lazy("."), PreludeBase.TList.DList.<String/*<Character>*/>mk()
-                          ),
-                      (long)Bits.TBitSet.<Short>fromList(
-                            Flags.IEnum_Flag.it,
-                            PreludeBase.TList.DCons.<Short>mk(
-                                  Thunk.<Short>lazy(Flags.TFlag.WARNINGS),
-                                  PreludeBase.TList.DCons.<Short>mk(
-                                        Thunk.<Short>lazy(Flags.TFlag.HINTS),
-                                        PreludeBase.TList.DCons.<Short>mk(
-                                              Thunk.<Short>lazy(Flags.TFlag.VERBOSE),
-                                              PreludeBase.TList.DCons.<Short>mk(
-                                                    Thunk.<Short>lazy(Flags.TFlag.IDEMODE),
-                                                    PreludeBase.TList.DCons.<Short>mk(
-                                                          Thunk.<Short>lazy(Flags.TFlag.IDETOKENS),
-                                                          PreludeBase.TList.DCons.<Short>mk(
-                                                                Thunk.<Short>lazy(Flags.TFlag.MAKE),
-                                                                PreludeBase.TList.DList.<
-                                                                  Short
-                                                                >mk()
-                                                              )
-                                                        )
-                                                  )
-                                            )
-                                      )
-                                )
-                          ),
-                      ".", PreludeBase.TList.DList.<String/*<Character>*/>mk(), "",
-                      PreludeBase.TMaybe.DJust.<String/*<Character>*/>mk(Thunk.<String/*<Character>*/>lazy("UTF-8")),
-                      PreludeBase.TList.DList.<PreludeBase.TTuple2<Integer, Integer>>mk(), Targets.thisTarget.call(),
-                      PreludeBase.TMaybe.DNothing.<frege.compiler.types.Types.TSigmaT<QNames.TQName>>mk(),
-                      PreludeBase.TList.DList.<frege.compiler.types.Types.TSigmaT<QNames.TQName>>mk(),
-                      PreludeBase.TList.DList.<Tokens.TToken>mk()
-                    );
-          })
-    );
 final public static State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, Short> runpass(
   final PreludeBase.TTuple2<
     State.TStateT<Global.TGlobal, Func.U<RealWorld, ?>, PreludeBase.TTuple2<String/*<Character>*/, Integer>>,

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileGlobal.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileGlobal.java
@@ -82,7 +82,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/compile/CompileGlobal.fr",
-  time=1658516064633L, jmajor=11, jminor=-1,
+  time=1658602828623L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.compile.CompileOptions", "frege.compiler.common.CompilerOptions",
     "frege.compiler.types.Global", "frege.Prelude", "frege.prelude.PreludeArrays", "frege.prelude.PreludeBase",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileGlobal.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileGlobal.java
@@ -82,7 +82,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/compile/CompileGlobal.fr",
-  time=1658602828623L, jmajor=11, jminor=-1,
+  time=1658948162095L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.compile.CompileOptions", "frege.compiler.common.CompilerOptions",
     "frege.compiler.types.Global", "frege.Prelude", "frege.prelude.PreludeArrays", "frege.prelude.PreludeBase",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileOptions.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileOptions.java
@@ -78,7 +78,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/compile/CompileOptions.fr",
-  time=1658602827601L, jmajor=11, jminor=-1,
+  time=1658948161221L, jmajor=11, jminor=-1,
   imps={
     "frege.compiler.enums.Flags", "frege.compiler.types.Global", "frege.Prelude", "frege.prelude.PreludeArrays",
     "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal", "frege.prelude.PreludeIO", "frege.prelude.PreludeList",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileOptions.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileOptions.java
@@ -78,7 +78,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/compile/CompileOptions.fr",
-  time=1658516063778L, jmajor=11, jminor=-1,
+  time=1658602827601L, jmajor=11, jminor=-1,
   imps={
     "frege.compiler.enums.Flags", "frege.compiler.types.Global", "frege.Prelude", "frege.prelude.PreludeArrays",
     "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal", "frege.prelude.PreludeIO", "frege.prelude.PreludeList",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.java
@@ -140,7 +140,7 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.fr",
-  time=1658602830223L, jmajor=11, jminor=-1,
+  time=1658948163560L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.compile.CompileExecutor",
     "ch.fhnw.thga.fregelanguageserver.compile.CompileGlobal", "frege.compiler.types.Global",
@@ -739,68 +739,63 @@ import frege.test.QuickCheckText;
       stri="s(s)", sig=34, depth=1, rkind=13
     ),
     @Meta.SymV(
-      offset=5292, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="posToTokens"),
+      offset=5169, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="posToTokens"),
       stri="s(su)", sig=37, depth=2, rkind=45
     ),
     @Meta.SymV(
-      offset=5433, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="main"),
+      offset=5310, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="main"),
       stri="u", sig=38, depth=0, rkind=8
     ),
     @Meta.SymV(
       offset=2300,
       name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="getDiagnostics"),
-      stri="s(s)", sig=40, depth=1, rkind=13
+      stri="s(u)", sig=39, depth=1, rkind=13
     ),
     @Meta.SymV(
       offset=826,
       name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="fromCompilerSeverity"),
-      stri="s(s)", sig=42, depth=1, rkind=13
+      stri="s(s)", sig=41, depth=1, rkind=13
     ),
     @Meta.SymV(
-      offset=3094,
+      offset=2883,
       name=@Meta.QName(
         pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic",
         base="fregeLSPServerShouldMapSingleCompilerMessageToDiagnostics"
       ),
-      stri="u", sig=43, depth=0, rkind=8
+      stri="u", sig=42, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=3890,
+      offset=3722,
       name=@Meta.QName(
         pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic",
         base="fregeLSPServerShouldMapMultipleCompilerMessageToDiagnostics"
       ),
-      stri="u", sig=43, depth=0, rkind=8
+      stri="u", sig=42, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=2649,
+      offset=2392,
       name=@Meta.QName(
         pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic",
         base="fregeLSPServerShouldMapNoCompilerMessagesToEmptyArray"
       ),
-      stri="u", sig=43, depth=0, rkind=8
+      stri="u", sig=42, depth=0, rkind=8
     ),
     @Meta.SymV(
       offset=2118,
       name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="extractDiagnostics"),
-      stri="s", sig=44, depth=0, rkind=13
+      stri="s", sig=43, depth=0, rkind=13
     ),
     @Meta.SymV(
       offset=1768,
       name=@Meta.QName(
         pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="createDiagnosticFromMessage"
       ),
-      stri="s(s)", sig=46, depth=1, rkind=13
+      stri="s(s)", sig=45, depth=1, rkind=13
     ),
     @Meta.SymV(
       offset=1618,
       name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="createRangeFromPos"),
-      stri="s(s)", sig=48, depth=1, rkind=13
-    ),
-    @Meta.SymV(
-      offset=2440,
-      name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="compileAndGetDiagnostics"),
-      stri="s(u)", sig=49, depth=1, rkind=13
+      stri="s(s)", sig=47, depth=1, rkind=13
     )
   },
   symls={
@@ -873,15 +868,15 @@ import frege.test.QuickCheckText;
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.prelude.PreludeBase", base="RealWorld")}),
     @Meta.Tau(kind=0, suba=26, subb=27),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.prelude.PreludeBase", base="()")}),
-    @Meta.Tau(kind=0, suba=28, subb=29), @Meta.Tau(kind=0, suba=28, subb=25), @Meta.Tau(kind=0, suba=28, subb=5),
+    @Meta.Tau(kind=0, suba=28, subb=29),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.compiler.types.Global", base="Severity")}),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.test.QuickCheckGen", base="Gen")}),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.test.QuickCheckProperty", base="Prop")}),
-    @Meta.Tau(kind=0, suba=34, subb=35),
+    @Meta.Tau(kind=0, suba=32, subb=33),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.control.monad.State", base="State")}),
-    @Meta.Tau(kind=0, suba=37, subb=25), @Meta.Tau(kind=0, suba=38, subb=5),
+    @Meta.Tau(kind=0, suba=35, subb=25), @Meta.Tau(kind=0, suba=36, subb=5),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.compiler.types.Global", base="Message")}),
-    @Meta.Tau(kind=0, suba=38, subb=0), @Meta.Tau(kind=0, suba=38, subb=11)
+    @Meta.Tau(kind=0, suba=36, subb=0), @Meta.Tau(kind=0, suba=36, subb=11)
   },
   rhos={
     @Meta.Rho(rhofun=false, rhotau=0), @Meta.Rho(rhofun=false, rhotau=3), @Meta.Rho(sigma=0, rhotau=1),
@@ -902,11 +897,10 @@ import frege.test.QuickCheckText;
     @Meta.Rho(rhofun=false, rhotau=20), @Meta.Rho(sigma=31, rhotau=0), @Meta.Rho(sigma=0, rhotau=46),
     @Meta.Rho(rhofun=false, rhotau=22), @Meta.Rho(sigma=33, rhotau=25), @Meta.Rho(rhofun=false, rhotau=24),
     @Meta.Rho(rhofun=false, rhotau=25), @Meta.Rho(sigma=36, rhotau=48), @Meta.Rho(sigma=35, rhotau=52),
-    @Meta.Rho(rhofun=false, rhotau=30), @Meta.Rho(rhofun=false, rhotau=31), @Meta.Rho(rhofun=false, rhotau=32),
-    @Meta.Rho(sigma=39, rhotau=56), @Meta.Rho(rhofun=false, rhotau=33), @Meta.Rho(sigma=41, rhotau=11),
-    @Meta.Rho(rhofun=false, rhotau=36), @Meta.Rho(rhofun=false, rhotau=39), @Meta.Rho(rhofun=false, rhotau=40),
-    @Meta.Rho(rhofun=false, rhotau=41), @Meta.Rho(sigma=45, rhotau=63), @Meta.Rho(rhofun=false, rhotau=23),
-    @Meta.Rho(rhofun=false, rhotau=42), @Meta.Rho(sigma=47, rhotau=66), @Meta.Rho(sigma=3, rhotau=56)
+    @Meta.Rho(rhofun=false, rhotau=30), @Meta.Rho(sigma=36, rhotau=3), @Meta.Rho(rhofun=false, rhotau=31),
+    @Meta.Rho(sigma=40, rhotau=11), @Meta.Rho(rhofun=false, rhotau=34), @Meta.Rho(rhofun=false, rhotau=37),
+    @Meta.Rho(rhofun=false, rhotau=38), @Meta.Rho(rhofun=false, rhotau=39), @Meta.Rho(sigma=44, rhotau=61),
+    @Meta.Rho(rhofun=false, rhotau=23), @Meta.Rho(rhofun=false, rhotau=40), @Meta.Rho(sigma=46, rhotau=64)
   },
   sigmas={
     @Meta.Sigma(rho=0), @Meta.Sigma(rho=2), @Meta.Sigma(rho=3), @Meta.Sigma(rho=1), @Meta.Sigma(rho=5),
@@ -917,9 +911,8 @@ import frege.test.QuickCheckText;
     @Meta.Sigma(rho=37), @Meta.Sigma(bound={"α"}, kinds={12}, rho=38), @Meta.Sigma(rho=39), @Meta.Sigma(rho=41),
     @Meta.Sigma(rho=42), @Meta.Sigma(rho=44), @Meta.Sigma(rho=45), @Meta.Sigma(rho=47), @Meta.Sigma(rho=48),
     @Meta.Sigma(rho=49), @Meta.Sigma(rho=50), @Meta.Sigma(rho=51), @Meta.Sigma(rho=53), @Meta.Sigma(rho=54),
-    @Meta.Sigma(rho=55), @Meta.Sigma(rho=57), @Meta.Sigma(rho=58), @Meta.Sigma(rho=59), @Meta.Sigma(rho=60),
-    @Meta.Sigma(rho=61), @Meta.Sigma(rho=62), @Meta.Sigma(rho=64), @Meta.Sigma(rho=65), @Meta.Sigma(rho=67),
-    @Meta.Sigma(rho=68)
+    @Meta.Sigma(rho=55), @Meta.Sigma(rho=56), @Meta.Sigma(rho=57), @Meta.Sigma(rho=58), @Meta.Sigma(rho=59),
+    @Meta.Sigma(rho=60), @Meta.Sigma(rho=62), @Meta.Sigma(rho=63), @Meta.Sigma(rho=65)
   },
   exprs={@Meta.Expr()}
 )
@@ -953,14 +946,14 @@ final public static class IShow_Diagnostic implements PreludeText.CShow<TDiagnos
     return IShow_Diagnostic.showChars(arg$1.call());
   }
   final public static String/*<Character>*/ showsub(final TDiagnostic arg$1) {
-    final String/*<Character>*/ a4$17478 = arg$1.mem$message.call();
-    final String/*<Character>*/ a3$17477 = arg$1.mem$source.call();
-    final short a2$17476 = (short)arg$1.mem$severity.call();
-    final Range.TRange a1$17475 = arg$1.mem$range.call();
-    return ("(" + (((((((("Diagnostic" + " ") + Range.IShow_Range.showsub(a1$17475)) + " ") + IShow_DiagnosticSeverity.showsub(
-              a2$17476
-            )) + " ") + PreludeText.IShow_String.showsub(a3$17477)) + " ") + PreludeText.IShow_String.showsub(
-              a4$17478
+    final String/*<Character>*/ a4$17477 = arg$1.mem$message.call();
+    final String/*<Character>*/ a3$17476 = arg$1.mem$source.call();
+    final short a2$17475 = (short)arg$1.mem$severity.call();
+    final Range.TRange a1$17474 = arg$1.mem$range.call();
+    return ("(" + (((((((("Diagnostic" + " ") + Range.IShow_Range.showsub(a1$17474)) + " ") + IShow_DiagnosticSeverity.showsub(
+              a2$17475
+            )) + " ") + PreludeText.IShow_String.showsub(a3$17476)) + " ") + PreludeText.IShow_String.showsub(
+              a4$17477
             ))) + ")";
   }
   final public static String/*<Character>*/ showList(
@@ -969,9 +962,9 @@ final public static class IShow_Diagnostic implements PreludeText.CShow<TDiagnos
     return "[" + (PreludeText.joined(
               Thunk.<String/*<Character>*/>lazy(", "),
               PreludeList.<String/*<Character>*/, TDiagnostic>map(
-                    (Func.U<TDiagnostic, String/*<Character>*/>)((final Lazy<TDiagnostic> η$18681) -> Thunk.<
+                    (Func.U<TDiagnostic, String/*<Character>*/>)((final Lazy<TDiagnostic> η$18710) -> Thunk.<
                           String/*<Character>*/
-                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_Diagnostic.show(η$18681.call())))),
+                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_Diagnostic.show(η$18710.call())))),
                     arg$1
                   )
             ).call() + ("]" + arg$2));
@@ -985,36 +978,14 @@ final public static class IShow_Diagnostic implements PreludeText.CShow<TDiagnos
     return IShow_Diagnostic.show(arg$1);
   }
   final public static String/*<Character>*/ show(final TDiagnostic arg$1) {
-    final String/*<Character>*/ a4$17471 = arg$1.mem$message.call();
-    final String/*<Character>*/ a3$17470 = arg$1.mem$source.call();
-    final short a2$17469 = (short)arg$1.mem$severity.call();
-    final Range.TRange a1$17468 = arg$1.mem$range.call();
-    return ((((((("Diagnostic" + " ") + Range.IShow_Range.showsub(a1$17468)) + " ") + IShow_DiagnosticSeverity.showsub(
-              a2$17469
-            )) + " ") + PreludeText.IShow_String.showsub(a3$17470)) + " ") + PreludeText.IShow_String.showsub(
-              a4$17471
-            );
-  }
-  final public static PreludeBase.TList<Character> showChars(final TDiagnostic arg$1) {
-    return PreludeList.IListView_StringJ.<Character>toList(IShow_Diagnostic.show(arg$1));
-  }
-  final public static String/*<Character>*/ showsPrec(
-    final Lazy<Integer> arg$1, final TDiagnostic arg$2, final String/*<Character>*/ arg$3
-  ) {
-    return IShow_Diagnostic.show(arg$2) + arg$3;
-  }
-  final public static String/*<Character>*/ display(final TDiagnostic arg$1) {
-    return IShow_Diagnostic.show(arg$1);
-  }
-  final public static String/*<Character>*/ show(final TDiagnostic arg$1) {
-    final String/*<Character>*/ a4$17469 = arg$1.mem$message.call();
-    final String/*<Character>*/ a3$17468 = arg$1.mem$source.call();
-    final short a2$17467 = (short)arg$1.mem$severity.call();
-    final Range.TRange a1$17466 = arg$1.mem$range.call();
-    return ((((((("Diagnostic" + " ") + Range.IShow_Range.showsub(a1$17466)) + " ") + IShow_DiagnosticSeverity.showsub(
-              a2$17467
-            )) + " ") + PreludeText.IShow_String.showsub(a3$17468)) + " ") + PreludeText.IShow_String.showsub(
-              a4$17469
+    final String/*<Character>*/ a4$17472 = arg$1.mem$message.call();
+    final String/*<Character>*/ a3$17471 = arg$1.mem$source.call();
+    final short a2$17470 = (short)arg$1.mem$severity.call();
+    final Range.TRange a1$17469 = arg$1.mem$range.call();
+    return ((((((("Diagnostic" + " ") + Range.IShow_Range.showsub(a1$17469)) + " ") + IShow_DiagnosticSeverity.showsub(
+              a2$17470
+            )) + " ") + PreludeText.IShow_String.showsub(a3$17471)) + " ") + PreludeText.IShow_String.showsub(
+              a4$17472
             );
   }
   final public static PreludeBase.TList<Character> showChars(final TDiagnostic arg$1) {
@@ -1063,9 +1034,9 @@ final public static class IShow_DiagnosticSeverity implements PreludeText.CShow<
     return "[" + (PreludeText.joined(
               Thunk.<String/*<Character>*/>lazy(", "),
               PreludeList.<String/*<Character>*/, Short>map(
-                    (Func.U<Short, String/*<Character>*/>)((final Lazy<Short> η$18695) -> Thunk.<
+                    (Func.U<Short, String/*<Character>*/>)((final Lazy<Short> η$18724) -> Thunk.<
                           String/*<Character>*/
-                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_DiagnosticSeverity.show((short)η$18695.call())))),
+                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_DiagnosticSeverity.show((short)η$18724.call())))),
                     arg$1
                   )
             ).call() + ("]" + arg$2));
@@ -1108,13 +1079,13 @@ final public static class IEq_Diagnostic implements PreludeBase.CEq<TDiagnostic>
     return IEq_Diagnostic.$eq$eq(arg$1.call(), arg$2.call());
   }
   final public static int hashCode(final TDiagnostic arg$1) {
-    final String/*<Character>*/ a4$17466 = arg$1.mem$message.call();
-    final String/*<Character>*/ a3$17465 = arg$1.mem$source.call();
-    final short a2$17464 = (short)arg$1.mem$severity.call();
-    final Range.TRange a1$17463 = arg$1.mem$range.call();
+    final String/*<Character>*/ a4$17467 = arg$1.mem$message.call();
+    final String/*<Character>*/ a3$17466 = arg$1.mem$source.call();
+    final short a2$17465 = (short)arg$1.mem$severity.call();
+    final Range.TRange a1$17464 = arg$1.mem$range.call();
     return (31 * ((31 * ((31 * ((31 * ((31 * 1) + RunTM.constructor(arg$1))) + Range.IEq_Range.hashCode(
-              a1$17463
-            ))) + IEq_DiagnosticSeverity.hashCode(a2$17464))) + a3$17465.hashCode())) + a4$17466
+              a1$17464
+            ))) + IEq_DiagnosticSeverity.hashCode(a2$17465))) + a3$17466.hashCode())) + a4$17467
         .hashCode();
   }
   final public static boolean $excl$eq(final TDiagnostic arg$1, final TDiagnostic arg$2) {
@@ -1126,17 +1097,17 @@ final public static class IEq_Diagnostic implements PreludeBase.CEq<TDiagnostic>
     }
   }
   final public static boolean $eq$eq(final TDiagnostic arg$1, final TDiagnostic arg$2) {
-    final String/*<Character>*/ µ$$17538 = arg$1.mem$message.call();
-    final String/*<Character>*/ µ$$17537 = arg$1.mem$source.call();
-    final short µ$$17536 = (short)arg$1.mem$severity.call();
-    final Range.TRange µ$$17535 = arg$1.mem$range.call();
-    final String/*<Character>*/ µ$$17542 = arg$2.mem$message.call();
-    final String/*<Character>*/ µ$$17541 = arg$2.mem$source.call();
-    final short µ$$17540 = (short)arg$2.mem$severity.call();
-    final Range.TRange µ$$17539 = arg$2.mem$range.call();
-    return Range.IEq_Range.$eq$eq(µ$$17535, µ$$17539) && (IEq_DiagnosticSeverity.$eq$eq(
-              µ$$17536, µ$$17540
-            ) && (µ$$17537.equals(µ$$17541) && µ$$17538.equals(µ$$17542)));
+    final String/*<Character>*/ µ$$17539 = arg$1.mem$message.call();
+    final String/*<Character>*/ µ$$17538 = arg$1.mem$source.call();
+    final short µ$$17537 = (short)arg$1.mem$severity.call();
+    final Range.TRange µ$$17536 = arg$1.mem$range.call();
+    final String/*<Character>*/ µ$$17543 = arg$2.mem$message.call();
+    final String/*<Character>*/ µ$$17542 = arg$2.mem$source.call();
+    final short µ$$17541 = (short)arg$2.mem$severity.call();
+    final Range.TRange µ$$17540 = arg$2.mem$range.call();
+    return Range.IEq_Range.$eq$eq(µ$$17536, µ$$17540) && (IEq_DiagnosticSeverity.$eq$eq(
+              µ$$17537, µ$$17541
+            ) && (µ$$17538.equals(µ$$17542) && µ$$17539.equals(µ$$17543)));
   }
 }
 final public static class IEq_DiagnosticSeverity implements PreludeBase.CEq<Short> {
@@ -1226,19 +1197,19 @@ final public static class TDiagnostic implements frege.runtime.Value, Lazy<TDiag
     return TDiagnostic.mk(arg$1.mem$range, arg$2, arg$1.mem$source, arg$1.mem$message);
   }
   final public static String/*<Character>*/ source(final TDiagnostic arg$1) {
-    final String/*<Character>*/ a3$17395 = arg$1.mem$source.call();
-    return a3$17395;
+    final String/*<Character>*/ a3$17394 = arg$1.mem$source.call();
+    return a3$17394;
   }
   final public static TDiagnostic upd$message(final TDiagnostic arg$1, final Lazy<String/*<Character>*/> arg$2) {
     return TDiagnostic.mk(arg$1.mem$range, arg$1.mem$severity, arg$1.mem$source, arg$2);
   }
   final public static Range.TRange range(final TDiagnostic arg$1) {
-    final Range.TRange a1$17357 = arg$1.mem$range.call();
-    return a1$17357;
+    final Range.TRange a1$17356 = arg$1.mem$range.call();
+    return a1$17356;
   }
   final public static short severity(final TDiagnostic arg$1) {
-    final short a2$17376 = (short)arg$1.mem$severity.call();
-    return a2$17376;
+    final short a2$17375 = (short)arg$1.mem$severity.call();
+    return a2$17375;
   }
   final public static <α> boolean has$source(final Lazy<α> arg$1) {
     return true;
@@ -1286,8 +1257,8 @@ final public static class TDiagnostic implements frege.runtime.Value, Lazy<TDiag
     return true;
   }
   final public static String/*<Character>*/ message(final TDiagnostic arg$1) {
-    final String/*<Character>*/ a4$17342 = arg$1.mem$message.call();
-    return a4$17342;
+    final String/*<Character>*/ a4$17341 = arg$1.mem$message.call();
+    return a4$17341;
   }
 }
 final public static class TDiagnosticSeverity  {
@@ -1297,40 +1268,40 @@ final public static class TDiagnosticSeverity  {
   final public static short INFORMATION = 2;
 }
 final public static Range.TRange tokensToRange(final PreludeBase.TList<Tokens.TToken> arg$1) {
-  final PreludeBase.TList.DList<Tokens.TToken> $18722 = arg$1.asList();
-  if ($18722 != null) {
+  final PreludeBase.TList.DList<Tokens.TToken> $18751 = arg$1.asList();
+  if ($18751 != null) {
     return Range.TRange.mk(
               Position.TPosition.mk(Thunk.<Integer>lazy(1), Thunk.<Integer>lazy(0)),
               Position.TPosition.mk(Thunk.<Integer>lazy(2), Thunk.<Integer>lazy(0))
             );
   }
-  final PreludeBase.TList.DCons<Tokens.TToken> $18723 = arg$1.asCons();
-  if ($18723 != null) {
-    final PreludeBase.TList<Tokens.TToken> $18724 = $18723.mem2.call();
-    final PreludeBase.TList.DList<Tokens.TToken> $18725 = $18724.asList();
-    if ($18725 != null) {
-      final Tokens.TToken tk$17411 = $18723.mem1.call();
-      return Range.tokenToRange(tk$17411);
+  final PreludeBase.TList.DCons<Tokens.TToken> $18752 = arg$1.asCons();
+  if ($18752 != null) {
+    final PreludeBase.TList<Tokens.TToken> $18753 = $18752.mem2.call();
+    final PreludeBase.TList.DList<Tokens.TToken> $18754 = $18753.asList();
+    if ($18754 != null) {
+      final Tokens.TToken tk$17410 = $18752.mem1.call();
+      return Range.tokenToRange(tk$17410);
     }
   }
-  final Lazy<Tokens.TToken> endToken$17414 = Thunk.<Tokens.TToken>shared(
+  final Lazy<Tokens.TToken> endToken$17413 = Thunk.<Tokens.TToken>shared(
         (Lazy<Tokens.TToken>)(() -> PreludeList.<Tokens.TToken>last(arg$1))
       );
-  final Lazy<Tokens.TToken> startToken$17413 = Thunk.<Tokens.TToken>shared(
+  final Lazy<Tokens.TToken> startToken$17412 = Thunk.<Tokens.TToken>shared(
         (Lazy<Tokens.TToken>)(() -> PreludeList.IListView_$lbrack$rbrack.<Tokens.TToken>head(
                   arg$1
                 ))
       );
   return Range.TRange.mk(
             Position.TPosition.mk(
-                  Thunk.<Integer>lazy(Tokens.TToken.line(startToken$17413.call())),
-                  Thunk.<Integer>lazy(Tokens.TToken.col(startToken$17413.call()))
+                  Thunk.<Integer>lazy(Tokens.TToken.line(startToken$17412.call())),
+                  Thunk.<Integer>lazy(Tokens.TToken.col(startToken$17412.call()))
                 ),
             Position.TPosition.mk(
-                  Thunk.<Integer>lazy(Tokens.TToken.line(endToken$17414.call())),
+                  Thunk.<Integer>lazy(Tokens.TToken.line(endToken$17413.call())),
                   Thunk.<Integer>shared(
-                        (Lazy<Integer>)(() -> Tokens.TToken.col(endToken$17414.call()) + Tokens.TToken.value(
-                                  endToken$17414.call()
+                        (Lazy<Integer>)(() -> Tokens.TToken.col(endToken$17413.call()) + Tokens.TToken.value(
+                                  endToken$17413.call()
                                 ).length())
                       )
                 )
@@ -1339,61 +1310,65 @@ final public static Range.TRange tokensToRange(final PreludeBase.TList<Tokens.TT
 final public static PreludeBase.TList<Tokens.TToken> posToTokens(
   final PreludeBase.TList<Positions.TPosition> arg$1, final Lazy<Global.TGlobal> arg$2
 ) {
-  final PreludeBase.TList.DCons<Positions.TPosition> $18727 = arg$1.asCons();
-  if ($18727 != null) {
-    final Positions.TPosition µ$$17535 = $18727.mem1.call();
+  final PreludeBase.TList.DCons<Positions.TPosition> $18756 = arg$1.asCons();
+  if ($18756 != null) {
+    final Positions.TPosition µ$$17534 = $18756.mem1.call();
     return PreludeList.IListMonoid_$lbrack$rbrack.<Tokens.TToken>$plus$plus(
-              Global.tokens(µ$$17535, arg$2),
+              Global.tokens(µ$$17534, arg$2),
               Thunk.<PreludeBase.TList<Tokens.TToken>>shared(
                     (Lazy<PreludeBase.TList<Tokens.TToken>>)(() -> Diagnostic.posToTokens(
-                              $18727.mem2.call(), arg$2
+                              $18756.mem2.call(), arg$2
                             ))
                   )
             );
   }
-  final PreludeBase.TList.DList<Positions.TPosition> $18729 = arg$1.asList();
-  assert $18729 != null;
+  final PreludeBase.TList.DList<Positions.TPosition> $18758 = arg$1.asList();
+  assert $18758 != null;
   return PreludeBase.TList.DList.<Tokens.TToken>mk();
 }
 final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWorld, Short>>shared(
       (Lazy<Func.U<RealWorld, Short>>)(() -> {
-            return (Func.U<RealWorld, Short>)((final Lazy<RealWorld> arg$18730) -> {
-                      final Global.TGlobal v2056$18299 = CompileExecutor.compile(
+            return (Func.U<RealWorld, Short>)((final Lazy<RealWorld> arg$18759) -> {
+                      final Global.TGlobal v2056$18291 = CompileGlobal.standardCompileGlobal
+                      .call().apply(arg$18759).call();
+                      final Func.U<RealWorld, Global.TGlobal> v2053$18310 = CompileExecutor.compile(
                             Thunk.<String/*<Character>*/>lazy(
                                   "module FaultyFregeTest where\n\nsimplyString s = s\n\nerr1 = (simplyString 42) ++ \"test\""
                                 ),
-                            CompileGlobal.standardCompileGlobal.call()
-                          ).apply(arg$18730).call();
-                      final Func.U<RealWorld, Short> v4793$18321 = Prelude.<String/*<Character>*/>println(
-                            PreludeText.IShow_String.it, Global.TSubSt.code(Global.TGlobal.sub(v2056$18299)).toString()
+                            v2056$18291
                           );
-                      final short v4796$18323 = (short)v4793$18321.apply(arg$18730).call();
-                      final Func.U<RealWorld, Short> v4797$18324 = ((Func.U<RealWorld, Short>)((
-                        final Lazy<RealWorld> arg$18735
+                      final Global.TGlobal v2056$18313 = v2053$18310.apply(arg$18759)
+                      .call();
+                      final Func.U<RealWorld, Short> v4793$18335 = Prelude.<String/*<Character>*/>println(
+                            PreludeText.IShow_String.it, Global.TSubSt.code(Global.TGlobal.sub(v2056$18313)).toString()
+                          );
+                      final short v4796$18337 = (short)v4793$18335.apply(arg$18759).call();
+                      final Func.U<RealWorld, Short> v4797$18338 = ((Func.U<RealWorld, Short>)((
+                        final Lazy<RealWorld> arg$18766
                       ) -> {
-                            final short v4796$18354 = (short)Func.<RealWorld, Short>coerceU(
+                            final short v4796$18368 = (short)Func.<RealWorld, Short>coerceU(
                                   PreludeMonad.<Func.U<RealWorld, ?>, Global.TMessage, Short, PreludeBase.TList<?>>$for(
                                         PreludeMonad.IMonad_ST.<RealWorld>mk(),
                                         PreludeList.IListSource_$lbrack$rbrack.<PreludeBase.TList<?>>mk(),
                                         Thunk.<Kind.U<PreludeBase.TList<?>, Global.TMessage>>lazy(
                                               (Kind.U<PreludeBase.TList<?>, Global.TMessage>)Global.TSubSt.messages(
-                                                    Global.TGlobal.sub(v2056$18299)
+                                                    Global.TGlobal.sub(v2056$18313)
                                                   )
                                             ),
                                         (Func.U<Global.TMessage, Kind.U<Func.U<RealWorld, ?>, Short>>)((
-                                          final Lazy<Global.TMessage> η$18734
+                                          final Lazy<Global.TMessage> η$18765
                                         ) -> Thunk.<Kind.U<Func.U<RealWorld, ?>, Short>>shared(
                                                   (Lazy<Kind.U<Func.U<RealWorld, ?>, Short>>)(() -> (Kind.U<
                                                         Func.U<RealWorld, ?>, Short
                                                       >)Thunk.<Func.U<RealWorld, Short>>shared(
                                                             (Lazy<Func.U<RealWorld, Short>>)(() -> Prelude.<
                                                                   Global.TMessage
-                                                                >println(CompileExecutor.IShow_Message.it, η$18734.call()))
+                                                                >println(CompileExecutor.IShow_Message.it, η$18765.call()))
                                                           ).call())
                                                 ))
                                       )
-                                ).apply(arg$18735).call();
-                            final Func.U<RealWorld, Short> v4797$18355 = Thunk.<Func.U<RealWorld, Short>>shared(
+                                ).apply(arg$18766).call();
+                            final Func.U<RealWorld, Short> v4797$18369 = Thunk.<Func.U<RealWorld, Short>>shared(
                                   (Lazy<Func.U<RealWorld, Short>>)(() -> Func.<RealWorld, Short>coerceU(
                                             Thunk.<Kind.U<Func.U<RealWorld, ?>, Short>>shared(
                                                   (Lazy<Kind.U<Func.U<RealWorld, ?>, Short>>)(() -> PreludeMonad.<
@@ -1423,23 +1398,23 @@ final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWor
                                                                                               Global.TMessage,
                                                                                               Positions.TPosition
                                                                                             >)((
-                                                                                              final Lazy<Global.TMessage> η$18732
+                                                                                              final Lazy<Global.TMessage> η$18763
                                                                                             ) -> Global.TMessage.pos(
-                                                                                                      η$18732
+                                                                                                      η$18763
                                                                                                       .call()
                                                                                                     )),
                                                                                             Global.TSubSt.messages(
                                                                                                   Global.TGlobal.sub(
-                                                                                                        v2056$18299
+                                                                                                        v2056$18313
                                                                                                       )
                                                                                                 )
                                                                                           ),
-                                                                                      v2056$18299
+                                                                                      v2056$18313
                                                                                     ))
                                                                           ).call())
                                                                 ),
                                                             (Func.U<Tokens.TToken, Kind.U<Func.U<RealWorld, ?>, Short>>)((
-                                                              final Lazy<Tokens.TToken> η$18733
+                                                              final Lazy<Tokens.TToken> η$18764
                                                             ) -> Thunk.<Kind.U<Func.U<RealWorld, ?>, Short>>shared(
                                                                       (Lazy<Kind.U<Func.U<RealWorld, ?>, Short>>)(() -> (Kind.U<
                                                                             Func.U<RealWorld, ?>, Short
@@ -1450,7 +1425,7 @@ final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWor
                                                                                       Tokens.TToken
                                                                                     >println(
                                                                                           Tokens.IShow_Token.it,
-                                                                                          η$18733
+                                                                                          η$18764
                                                                                           .call()
                                                                                         ))
                                                                               ).call())
@@ -1459,9 +1434,9 @@ final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWor
                                                 ).call()
                                           ))
                                 ).call();
-                            return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$18355.apply(arg$18735)));
+                            return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$18369.apply(arg$18766)));
                           })).call();
-                      return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$18324.apply(arg$18730)));
+                      return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$18338.apply(arg$18759)));
                     });
           })
     );
@@ -1478,16 +1453,16 @@ final public static short fromCompilerSeverity(final short arg$1) {
 final public static State.TState<Global.TGlobal, Range.TRange> createRangeFromPos(final Positions.TPosition arg$1) {
   return State.TState.<Global.TGlobal, Range.TRange>mk(
             (Func.U<Global.TGlobal, PreludeBase.TTuple2<Range.TRange, Global.TGlobal>>)((
-              final Lazy<Global.TGlobal> arg$18741
+              final Lazy<Global.TGlobal> arg$18772
             ) -> {
-                  final State.TState<Global.TGlobal, Range.TRange> $18742 = State.IMonad_State.<
+                  final State.TState<Global.TGlobal, Range.TRange> $18773 = State.IMonad_State.<
                     Global.TGlobal, Range.TRange
-                  >pure(Diagnostic.tokensToRange(Global.tokens(arg$1, arg$18741)));
-                  final Func.U<Global.TGlobal, PreludeBase.TTuple2<Range.TRange, Global.TGlobal>> v7693$18584 =
-                  $18742.mem$fun;
+                  >pure(Diagnostic.tokensToRange(Global.tokens(arg$1, arg$18772)));
+                  final Func.U<Global.TGlobal, PreludeBase.TTuple2<Range.TRange, Global.TGlobal>> v7693$18642 =
+                  $18773.mem$fun;
                   return Thunk.<PreludeBase.TTuple2<Range.TRange, Global.TGlobal>>nested(
-                            (Lazy<Lazy<PreludeBase.TTuple2<Range.TRange, Global.TGlobal>>>)(() -> v7693$18584
-                                .apply(arg$18741))
+                            (Lazy<Lazy<PreludeBase.TTuple2<Range.TRange, Global.TGlobal>>>)(() -> v7693$18642
+                                .apply(arg$18772))
                           );
                 })
           );
@@ -1495,22 +1470,22 @@ final public static State.TState<Global.TGlobal, Range.TRange> createRangeFromPo
 final public static State.TState<Global.TGlobal, TDiagnostic> createDiagnosticFromMessage(
   final Global.TMessage arg$1
 ) {
-  final State.TState<Global.TGlobal, Range.TRange> $18744 = Diagnostic.createRangeFromPos(
+  final State.TState<Global.TGlobal, Range.TRange> $18775 = Diagnostic.createRangeFromPos(
         Global.TMessage.pos(arg$1)
       );
-  final Func.U<Global.TGlobal, PreludeBase.TTuple2<Range.TRange, Global.TGlobal>> v7688$18546 =
-  $18744.mem$fun;
+  final Func.U<Global.TGlobal, PreludeBase.TTuple2<Range.TRange, Global.TGlobal>> v7688$18604 =
+  $18775.mem$fun;
   return State.TState.<Global.TGlobal, TDiagnostic>mk(
             (Func.U<Global.TGlobal, PreludeBase.TTuple2<TDiagnostic, Global.TGlobal>>)((
-              final Lazy<Global.TGlobal> arg$18746
+              final Lazy<Global.TGlobal> arg$18777
             ) -> {
-                  final PreludeBase.TTuple2<Range.TRange, Global.TGlobal> $18747 = v7688$18546
-                  .apply(arg$18746).call();
-                  final State.TState<Global.TGlobal, TDiagnostic> $18748 = State.IMonad_State.<
+                  final PreludeBase.TTuple2<Range.TRange, Global.TGlobal> $18778 = v7688$18604
+                  .apply(arg$18777).call();
+                  final State.TState<Global.TGlobal, TDiagnostic> $18779 = State.IMonad_State.<
                     Global.TGlobal, TDiagnostic
                   >pure(
                         TDiagnostic.mk(
-                              $18747.mem1,
+                              $18778.mem1,
                               Thunk.<Short>shared(
                                     (Lazy<Short>)(() -> Diagnostic.fromCompilerSeverity(
                                               Global.TMessage.level(arg$1)
@@ -1520,11 +1495,11 @@ final public static State.TState<Global.TGlobal, TDiagnostic> createDiagnosticFr
                               Thunk.<String/*<Character>*/>lazy(Global.TMessage.text(arg$1))
                             )
                       );
-                  final Func.U<Global.TGlobal, PreludeBase.TTuple2<TDiagnostic, Global.TGlobal>> v7693$18551 =
-                  $18748.mem$fun;
+                  final Func.U<Global.TGlobal, PreludeBase.TTuple2<TDiagnostic, Global.TGlobal>> v7693$18609 =
+                  $18779.mem$fun;
                   return Thunk.<PreludeBase.TTuple2<TDiagnostic, Global.TGlobal>>nested(
-                            (Lazy<Lazy<PreludeBase.TTuple2<TDiagnostic, Global.TGlobal>>>)(() -> v7693$18551
-                                .apply($18747.mem2))
+                            (Lazy<Lazy<PreludeBase.TTuple2<TDiagnostic, Global.TGlobal>>>)(() -> v7693$18609
+                                .apply($18778.mem2))
                           );
                 })
           );
@@ -1532,55 +1507,37 @@ final public static State.TState<Global.TGlobal, TDiagnostic> createDiagnosticFr
 final public static State.TState<Global.TGlobal, PreludeBase.TList<TDiagnostic>> extractDiagnostics =
 State.TState.<Global.TGlobal, PreludeBase.TList<TDiagnostic>>mk(
       (Func.U<Global.TGlobal, PreludeBase.TTuple2<PreludeBase.TList<TDiagnostic>, Global.TGlobal>>)((
-        final Lazy<Global.TGlobal> arg$18750
+        final Lazy<Global.TGlobal> arg$18781
       ) -> {
-            final Global.TGlobal v7690$18513 = arg$18750.call();
-            final State.TState<Global.TGlobal, PreludeBase.TList<TDiagnostic>> $18753 =
+            final Global.TGlobal v7690$18571 = arg$18781.call();
+            final State.TState<Global.TGlobal, PreludeBase.TList<TDiagnostic>> $18784 =
             State.TState.<Global.TGlobal, PreludeBase.TList<TDiagnostic>>coerce(
                   PreludeMonad.<State.TState<Global.TGlobal, ?>, TDiagnostic>sequence(
                         State.IMonad_State.<Global.TGlobal>mk(), State.IMonad_State.<Global.TGlobal>mk(),
                         PreludeMonad.IFunctor_$lbrack$rbrack.<Global.TMessage, State.TState<Global.TGlobal, TDiagnostic>>fmap(
                               (Func.U<Global.TMessage, State.TState<Global.TGlobal, TDiagnostic>>)((
-                                final Lazy<Global.TMessage> η$18752
+                                final Lazy<Global.TMessage> η$18783
                               ) -> Thunk.<State.TState<Global.TGlobal, TDiagnostic>>shared(
                                         (Lazy<State.TState<
                                           Global.TGlobal, TDiagnostic
                                         >>)(() -> Diagnostic.createDiagnosticFromMessage(
-                                                  η$18752.call()
+                                                  η$18783.call()
                                                 ))
                                       )),
-                              Global.TSubSt.messages(Global.TGlobal.sub(v7690$18513))
+                              Global.TSubSt.messages(Global.TGlobal.sub(v7690$18571))
                             ).<Kind.U<State.TState<Global.TGlobal, ?>, TDiagnostic>>simsalabim()
                       )
                 );
-            final Func.U<Global.TGlobal, PreludeBase.TTuple2<PreludeBase.TList<TDiagnostic>, Global.TGlobal>> v7693$18516 =
-            $18753.mem$fun;
+            final Func.U<Global.TGlobal, PreludeBase.TTuple2<PreludeBase.TList<TDiagnostic>, Global.TGlobal>> v7693$18574 =
+            $18784.mem$fun;
             return Thunk.<PreludeBase.TTuple2<PreludeBase.TList<TDiagnostic>, Global.TGlobal>>nested(
-                      (Lazy<Lazy<PreludeBase.TTuple2<PreludeBase.TList<TDiagnostic>, Global.TGlobal>>>)(() -> v7693$18516
-                          .apply(v7690$18513))
+                      (Lazy<Lazy<PreludeBase.TTuple2<PreludeBase.TList<TDiagnostic>, Global.TGlobal>>>)(() -> v7693$18574
+                          .apply(v7690$18571))
                     );
           })
     );
-final public static Func.U<RealWorld, PreludeBase.TList<TDiagnostic>> getDiagnostics(
-  final Func.U<RealWorld, Global.TGlobal> arg$1
-) {
-  return (Func.U<RealWorld, PreludeBase.TList<TDiagnostic>>)((final Lazy<RealWorld> arg$18755) -> {
-            final Global.TGlobal v2056$18376 = arg$1.apply(arg$18755).call();
-            final Func.U<RealWorld, PreludeBase.TList<TDiagnostic>> v2057$18377 = PreludeMonad.IMonad_ST.<
-              RealWorld, PreludeBase.TList<TDiagnostic>
-            >pure(
-                  Thunk.<PreludeBase.TList<TDiagnostic>>shared(
-                        (Lazy<PreludeBase.TList<TDiagnostic>>)(() -> State.<
-                              Global.TGlobal, PreludeBase.TList<TDiagnostic>
-                            >evalState(Diagnostic.extractDiagnostics, v2056$18376))
-                      )
-                );
-            return Thunk.<PreludeBase.TList<TDiagnostic>>nested(
-                      (Lazy<Lazy<PreludeBase.TList<TDiagnostic>>>)(() -> v2057$18377.apply(
-                                arg$18755
-                              ))
-                    );
-          });
+final public static PreludeBase.TList<TDiagnostic> getDiagnostics(final Lazy<Global.TGlobal> arg$1) {
+  return State.<Global.TGlobal, PreludeBase.TList<TDiagnostic>>evalState(Diagnostic.extractDiagnostics, arg$1);
 }
 final public static Lazy<QuickCheckGen.TGen<
   QuickCheckProperty.TRose<QuickCheckProperty.TResult>
@@ -1597,18 +1554,19 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$18758) -> {
-                                            final PreludeBase.TList<TDiagnostic> v2056$18412 =
-                                            Diagnostic.getDiagnostics(
-                                                  CompileExecutor.compile(
-                                                        Thunk.<String/*<Character>*/>lazy(
-                                                              "module ch.fhnw.thga.FaultyFregeTest where\n\nimport Does.not.Exist"
-                                                            ),
-                                                        CompileGlobal.standardCompileGlobal
-                                                        .call()
-                                                      )
-                                                ).apply(arg$18758).call();
-                                            final Func.U<RealWorld, Boolean> v2057$18413 =
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$18786) -> {
+                                            final Global.TGlobal v2056$18404 = CompileGlobal.standardCompileGlobal
+                                            .call().apply(arg$18786).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$18423 =
+                                            CompileExecutor.compile(
+                                                  Thunk.<String/*<Character>*/>lazy(
+                                                        "module ch.fhnw.thga.FaultyFregeTest where\n\nimport Does.not.Exist"
+                                                      ),
+                                                  v2056$18404
+                                                );
+                                            final Global.TGlobal v2056$18426 = v2053$18423
+                                            .apply(arg$18786).call();
+                                            final Func.U<RealWorld, Boolean> v2057$18427 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> PreludeBase.IEq_$lbrack$rbrack.<
@@ -1659,13 +1617,19 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                           TDiagnostic
                                                                         >mk()
                                                                       ),
-                                                                  v2056$18412
+                                                                  Thunk.<PreludeBase.TList<TDiagnostic>>shared(
+                                                                        (Lazy<PreludeBase.TList<
+                                                                          TDiagnostic
+                                                                        >>)(() -> Diagnostic.getDiagnostics(
+                                                                                  v2056$18426
+                                                                                ))
+                                                                      )
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18413
-                                                          .apply(arg$18758))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18427
+                                                          .apply(arg$18786))
                                                     );
                                           })
                                     ))
@@ -1688,33 +1652,40 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$18761) -> {
-                                            final PreludeBase.TList<TDiagnostic> v2056$18484 =
-                                            Diagnostic.getDiagnostics(
-                                                  CompileExecutor.compile(
-                                                        Thunk.<String/*<Character>*/>shared(
-                                                              (Lazy<String/*
-                                                                <Character>
-                                                              */>)(() -> "module CorrectFregeTest where\n\n" + "ok = 42 + 42")
-                                                            ),
-                                                        CompileGlobal.standardCompileGlobal
-                                                        .call()
-                                                      )
-                                                ).apply(arg$18761).call();
-                                            final Func.U<RealWorld, Boolean> v2057$18485 =
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$18791) -> {
+                                            final Global.TGlobal v2056$18520 = CompileGlobal.standardCompileGlobal
+                                            .call().apply(arg$18791).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$18539 =
+                                            CompileExecutor.compile(
+                                                  Thunk.<String/*<Character>*/>shared(
+                                                        (Lazy<String/*
+                                                          <Character>
+                                                        */>)(() -> "module CorrectFregeTest where\n\n" + "ok = 42 + 42")
+                                                      ),
+                                                  v2056$18520
+                                                );
+                                            final Global.TGlobal v2056$18542 = v2053$18539
+                                            .apply(arg$18791).call();
+                                            final Func.U<RealWorld, Boolean> v2057$18543 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> PreludeBase.IEq_$lbrack$rbrack.<
                                                               TDiagnostic
                                                             >$eq$eq(
                                                                   IEq_Diagnostic.it, PreludeBase.TList.DList.<TDiagnostic>mk(),
-                                                                  v2056$18484
+                                                                  Thunk.<PreludeBase.TList<TDiagnostic>>shared(
+                                                                        (Lazy<PreludeBase.TList<
+                                                                          TDiagnostic
+                                                                        >>)(() -> Diagnostic.getDiagnostics(
+                                                                                  v2056$18542
+                                                                                ))
+                                                                      )
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18485
-                                                          .apply(arg$18761))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18543
+                                                          .apply(arg$18791))
                                                     );
                                           })
                                     ))
@@ -1737,18 +1708,19 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$18764) -> {
-                                            final PreludeBase.TList<TDiagnostic> v2056$18448 =
-                                            Diagnostic.getDiagnostics(
-                                                  CompileExecutor.compile(
-                                                        Thunk.<String/*<Character>*/>lazy(
-                                                              "module ch.fhnw.thga.FaultyFregeTest where\n\nerr1 = do\n  x = 42\n\nerr2 = [ 22.0 ] ++ \"42\"\n\nerr3 = 42 + \"42\""
-                                                            ),
-                                                        CompileGlobal.standardCompileGlobal
-                                                        .call()
-                                                      )
-                                                ).apply(arg$18764).call();
-                                            final Func.U<RealWorld, Boolean> v2057$18449 =
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$18796) -> {
+                                            final Global.TGlobal v2056$18462 = CompileGlobal.standardCompileGlobal
+                                            .call().apply(arg$18796).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$18481 =
+                                            CompileExecutor.compile(
+                                                  Thunk.<String/*<Character>*/>lazy(
+                                                        "module ch.fhnw.thga.FaultyFregeTest where\n\nerr1 = do\n  x = 42\n\nerr2 = [ 22.0 ] ++ \"42\"\n\nerr3 = 42 + \"42\""
+                                                      ),
+                                                  v2056$18462
+                                                );
+                                            final Global.TGlobal v2056$18484 = v2053$18481
+                                            .apply(arg$18796).call();
+                                            final Func.U<RealWorld, Boolean> v2057$18485 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> PreludeBase.IEq_$lbrack$rbrack.<
@@ -1909,13 +1881,19 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                                   )
                                                                             )
                                                                       ),
-                                                                  v2056$18448
+                                                                  Thunk.<PreludeBase.TList<TDiagnostic>>shared(
+                                                                        (Lazy<PreludeBase.TList<
+                                                                          TDiagnostic
+                                                                        >>)(() -> Diagnostic.getDiagnostics(
+                                                                                  v2056$18484
+                                                                                ))
+                                                                      )
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18449
-                                                          .apply(arg$18764))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18485
+                                                          .apply(arg$18796))
                                                     );
                                           })
                                     ))
@@ -1923,28 +1901,6 @@ final public static Lazy<QuickCheckGen.TGen<
                     );
           })
     );
-final public static Func.U<RealWorld, PreludeBase.TList<TDiagnostic>> compileAndGetDiagnostics(
-  final Lazy<String/*<Character>*/> arg$1
-) {
-  return (Func.U<RealWorld, PreludeBase.TList<TDiagnostic>>)((final Lazy<RealWorld> arg$18767) -> {
-            final Global.TGlobal v2056$18623 = CompileExecutor.compile(arg$1, CompileGlobal.standardCompileGlobal.call())
-            .apply(arg$18767).call();
-            final Func.U<RealWorld, PreludeBase.TList<TDiagnostic>> v2057$18624 = PreludeMonad.IMonad_ST.<
-              RealWorld, PreludeBase.TList<TDiagnostic>
-            >pure(
-                  Thunk.<PreludeBase.TList<TDiagnostic>>shared(
-                        (Lazy<PreludeBase.TList<TDiagnostic>>)(() -> State.<
-                              Global.TGlobal, PreludeBase.TList<TDiagnostic>
-                            >evalState(Diagnostic.extractDiagnostics, v2056$18623))
-                      )
-                );
-            return Thunk.<PreludeBase.TList<TDiagnostic>>nested(
-                      (Lazy<Lazy<PreludeBase.TList<TDiagnostic>>>)(() -> v2057$18624.apply(
-                                arg$18767
-                              ))
-                    );
-          });
-}
 
   public static void main(final java.lang.String[] argv) {
     try {

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.java
@@ -947,14 +947,14 @@ final public static class IShow_Diagnostic implements PreludeText.CShow<TDiagnos
     return IShow_Diagnostic.showChars(arg$1.call());
   }
   final public static String/*<Character>*/ showsub(final TDiagnostic arg$1) {
-    final String/*<Character>*/ a4$17474 = arg$1.mem$message.call();
-    final String/*<Character>*/ a3$17473 = arg$1.mem$source.call();
-    final short a2$17472 = (short)arg$1.mem$severity.call();
-    final Range.TRange a1$17471 = arg$1.mem$range.call();
-    return ("(" + (((((((("Diagnostic" + " ") + Range.IShow_Range.showsub(a1$17471)) + " ") + IShow_DiagnosticSeverity.showsub(
-              a2$17472
-            )) + " ") + PreludeText.IShow_String.showsub(a3$17473)) + " ") + PreludeText.IShow_String.showsub(
-              a4$17474
+    final String/*<Character>*/ a4$17476 = arg$1.mem$message.call();
+    final String/*<Character>*/ a3$17475 = arg$1.mem$source.call();
+    final short a2$17474 = (short)arg$1.mem$severity.call();
+    final Range.TRange a1$17473 = arg$1.mem$range.call();
+    return ("(" + (((((((("Diagnostic" + " ") + Range.IShow_Range.showsub(a1$17473)) + " ") + IShow_DiagnosticSeverity.showsub(
+              a2$17474
+            )) + " ") + PreludeText.IShow_String.showsub(a3$17475)) + " ") + PreludeText.IShow_String.showsub(
+              a4$17476
             ))) + ")";
   }
   final public static String/*<Character>*/ showList(
@@ -979,14 +979,14 @@ final public static class IShow_Diagnostic implements PreludeText.CShow<TDiagnos
     return IShow_Diagnostic.show(arg$1);
   }
   final public static String/*<Character>*/ show(final TDiagnostic arg$1) {
-    final String/*<Character>*/ a4$17469 = arg$1.mem$message.call();
-    final String/*<Character>*/ a3$17468 = arg$1.mem$source.call();
-    final short a2$17467 = (short)arg$1.mem$severity.call();
-    final Range.TRange a1$17466 = arg$1.mem$range.call();
-    return ((((((("Diagnostic" + " ") + Range.IShow_Range.showsub(a1$17466)) + " ") + IShow_DiagnosticSeverity.showsub(
-              a2$17467
-            )) + " ") + PreludeText.IShow_String.showsub(a3$17468)) + " ") + PreludeText.IShow_String.showsub(
-              a4$17469
+    final String/*<Character>*/ a4$17471 = arg$1.mem$message.call();
+    final String/*<Character>*/ a3$17470 = arg$1.mem$source.call();
+    final short a2$17469 = (short)arg$1.mem$severity.call();
+    final Range.TRange a1$17468 = arg$1.mem$range.call();
+    return ((((((("Diagnostic" + " ") + Range.IShow_Range.showsub(a1$17468)) + " ") + IShow_DiagnosticSeverity.showsub(
+              a2$17469
+            )) + " ") + PreludeText.IShow_String.showsub(a3$17470)) + " ") + PreludeText.IShow_String.showsub(
+              a4$17471
             );
   }
   final public static PreludeBase.TList<Character> showChars(final TDiagnostic arg$1) {
@@ -1080,13 +1080,13 @@ final public static class IEq_Diagnostic implements PreludeBase.CEq<TDiagnostic>
     return IEq_Diagnostic.$eq$eq(arg$1.call(), arg$2.call());
   }
   final public static int hashCode(final TDiagnostic arg$1) {
-    final String/*<Character>*/ a4$17464 = arg$1.mem$message.call();
-    final String/*<Character>*/ a3$17463 = arg$1.mem$source.call();
-    final short a2$17462 = (short)arg$1.mem$severity.call();
-    final Range.TRange a1$17461 = arg$1.mem$range.call();
+    final String/*<Character>*/ a4$17466 = arg$1.mem$message.call();
+    final String/*<Character>*/ a3$17465 = arg$1.mem$source.call();
+    final short a2$17464 = (short)arg$1.mem$severity.call();
+    final Range.TRange a1$17463 = arg$1.mem$range.call();
     return (31 * ((31 * ((31 * ((31 * ((31 * 1) + RunTM.constructor(arg$1))) + Range.IEq_Range.hashCode(
-              a1$17461
-            ))) + IEq_DiagnosticSeverity.hashCode(a2$17462))) + a3$17463.hashCode())) + a4$17464
+              a1$17463
+            ))) + IEq_DiagnosticSeverity.hashCode(a2$17464))) + a3$17465.hashCode())) + a4$17466
         .hashCode();
   }
   final public static boolean $excl$eq(final TDiagnostic arg$1, final TDiagnostic arg$2) {
@@ -1098,17 +1098,17 @@ final public static class IEq_Diagnostic implements PreludeBase.CEq<TDiagnostic>
     }
   }
   final public static boolean $eq$eq(final TDiagnostic arg$1, final TDiagnostic arg$2) {
-    final String/*<Character>*/ µ$$17536 = arg$1.mem$message.call();
-    final String/*<Character>*/ µ$$17535 = arg$1.mem$source.call();
-    final short µ$$17534 = (short)arg$1.mem$severity.call();
-    final Range.TRange µ$$17533 = arg$1.mem$range.call();
-    final String/*<Character>*/ µ$$17540 = arg$2.mem$message.call();
-    final String/*<Character>*/ µ$$17539 = arg$2.mem$source.call();
-    final short µ$$17538 = (short)arg$2.mem$severity.call();
-    final Range.TRange µ$$17537 = arg$2.mem$range.call();
-    return Range.IEq_Range.$eq$eq(µ$$17533, µ$$17537) && (IEq_DiagnosticSeverity.$eq$eq(
-              µ$$17534, µ$$17538
-            ) && (µ$$17535.equals(µ$$17539) && µ$$17536.equals(µ$$17540)));
+    final String/*<Character>*/ µ$$17538 = arg$1.mem$message.call();
+    final String/*<Character>*/ µ$$17537 = arg$1.mem$source.call();
+    final short µ$$17536 = (short)arg$1.mem$severity.call();
+    final Range.TRange µ$$17535 = arg$1.mem$range.call();
+    final String/*<Character>*/ µ$$17542 = arg$2.mem$message.call();
+    final String/*<Character>*/ µ$$17541 = arg$2.mem$source.call();
+    final short µ$$17540 = (short)arg$2.mem$severity.call();
+    final Range.TRange µ$$17539 = arg$2.mem$range.call();
+    return Range.IEq_Range.$eq$eq(µ$$17535, µ$$17539) && (IEq_DiagnosticSeverity.$eq$eq(
+              µ$$17536, µ$$17540
+            ) && (µ$$17537.equals(µ$$17541) && µ$$17538.equals(µ$$17542)));
   }
 }
 final public static class IEq_DiagnosticSeverity implements PreludeBase.CEq<Short> {
@@ -1315,7 +1315,7 @@ final public static PreludeBase.TList<Tokens.TToken> posToTokens(
   if ($18723 != null) {
     final Positions.TPosition µ$$17531 = $18723.mem1.call();
     return PreludeList.IListMonoid_$lbrack$rbrack.<Tokens.TToken>$plus$plus(
-              Global.tokens(µ$$17531, arg$2),
+              Global.tokens(µ$$17533, arg$2),
               Thunk.<PreludeBase.TList<Tokens.TToken>>shared(
                     (Lazy<PreludeBase.TList<Tokens.TToken>>)(() -> Diagnostic.posToTokens(
                               $18723.mem2.call(), arg$2

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.java
@@ -140,7 +140,7 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.fr",
-  time=1658516066148L, jmajor=11, jminor=-1,
+  time=1658602830223L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.compile.CompileExecutor",
     "ch.fhnw.thga.fregelanguageserver.compile.CompileGlobal", "frege.compiler.types.Global",
@@ -739,63 +739,68 @@ import frege.test.QuickCheckText;
       stri="s(s)", sig=34, depth=1, rkind=13
     ),
     @Meta.SymV(
-      offset=5073, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="posToTokens"),
+      offset=5292, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="posToTokens"),
       stri="s(su)", sig=37, depth=2, rkind=45
     ),
     @Meta.SymV(
-      offset=5214, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="main"),
+      offset=5433, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="main"),
       stri="u", sig=38, depth=0, rkind=8
+    ),
+    @Meta.SymV(
+      offset=2300,
+      name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="getDiagnostics"),
+      stri="s(s)", sig=40, depth=1, rkind=13
     ),
     @Meta.SymV(
       offset=826,
       name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="fromCompilerSeverity"),
-      stri="s(s)", sig=40, depth=1, rkind=13
+      stri="s(s)", sig=42, depth=1, rkind=13
     ),
     @Meta.SymV(
-      offset=2902,
+      offset=3094,
       name=@Meta.QName(
         pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic",
         base="fregeLSPServerShouldMapSingleCompilerMessageToDiagnostics"
       ),
-      stri="u", sig=41, depth=0, rkind=8
+      stri="u", sig=43, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=3685,
+      offset=3890,
       name=@Meta.QName(
         pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic",
         base="fregeLSPServerShouldMapMultipleCompilerMessageToDiagnostics"
       ),
-      stri="u", sig=41, depth=0, rkind=8
+      stri="u", sig=43, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=2509,
+      offset=2649,
       name=@Meta.QName(
         pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic",
         base="fregeLSPServerShouldMapNoCompilerMessagesToEmptyArray"
       ),
-      stri="u", sig=41, depth=0, rkind=8
+      stri="u", sig=43, depth=0, rkind=8
     ),
     @Meta.SymV(
       offset=2118,
       name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="extractDiagnostics"),
-      stri="s", sig=42, depth=0, rkind=13
+      stri="s", sig=44, depth=0, rkind=13
     ),
     @Meta.SymV(
       offset=1768,
       name=@Meta.QName(
         pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="createDiagnosticFromMessage"
       ),
-      stri="s(s)", sig=44, depth=1, rkind=13
+      stri="s(s)", sig=46, depth=1, rkind=13
     ),
     @Meta.SymV(
       offset=1618,
       name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="createRangeFromPos"),
-      stri="s(s)", sig=46, depth=1, rkind=13
+      stri="s(s)", sig=48, depth=1, rkind=13
     ),
     @Meta.SymV(
-      offset=2300,
+      offset=2440,
       name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", base="compileAndGetDiagnostics"),
-      stri="s(u)", sig=47, depth=1, rkind=13
+      stri="s(u)", sig=49, depth=1, rkind=13
     )
   },
   symls={
@@ -868,15 +873,15 @@ import frege.test.QuickCheckText;
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.prelude.PreludeBase", base="RealWorld")}),
     @Meta.Tau(kind=0, suba=26, subb=27),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.prelude.PreludeBase", base="()")}),
-    @Meta.Tau(kind=0, suba=28, subb=29),
+    @Meta.Tau(kind=0, suba=28, subb=29), @Meta.Tau(kind=0, suba=28, subb=25), @Meta.Tau(kind=0, suba=28, subb=5),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.compiler.types.Global", base="Severity")}),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.test.QuickCheckGen", base="Gen")}),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.test.QuickCheckProperty", base="Prop")}),
-    @Meta.Tau(kind=0, suba=32, subb=33),
+    @Meta.Tau(kind=0, suba=34, subb=35),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.control.monad.State", base="State")}),
-    @Meta.Tau(kind=0, suba=35, subb=25), @Meta.Tau(kind=0, suba=36, subb=5),
+    @Meta.Tau(kind=0, suba=37, subb=25), @Meta.Tau(kind=0, suba=38, subb=5),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.compiler.types.Global", base="Message")}),
-    @Meta.Tau(kind=0, suba=36, subb=0), @Meta.Tau(kind=0, suba=36, subb=11), @Meta.Tau(kind=0, suba=28, subb=5)
+    @Meta.Tau(kind=0, suba=38, subb=0), @Meta.Tau(kind=0, suba=38, subb=11)
   },
   rhos={
     @Meta.Rho(rhofun=false, rhotau=0), @Meta.Rho(rhofun=false, rhotau=3), @Meta.Rho(sigma=0, rhotau=1),
@@ -897,11 +902,11 @@ import frege.test.QuickCheckText;
     @Meta.Rho(rhofun=false, rhotau=20), @Meta.Rho(sigma=31, rhotau=0), @Meta.Rho(sigma=0, rhotau=46),
     @Meta.Rho(rhofun=false, rhotau=22), @Meta.Rho(sigma=33, rhotau=25), @Meta.Rho(rhofun=false, rhotau=24),
     @Meta.Rho(rhofun=false, rhotau=25), @Meta.Rho(sigma=36, rhotau=48), @Meta.Rho(sigma=35, rhotau=52),
-    @Meta.Rho(rhofun=false, rhotau=30), @Meta.Rho(rhofun=false, rhotau=31), @Meta.Rho(sigma=39, rhotau=11),
-    @Meta.Rho(rhofun=false, rhotau=34), @Meta.Rho(rhofun=false, rhotau=37), @Meta.Rho(rhofun=false, rhotau=38),
-    @Meta.Rho(rhofun=false, rhotau=39), @Meta.Rho(sigma=43, rhotau=60), @Meta.Rho(rhofun=false, rhotau=23),
-    @Meta.Rho(rhofun=false, rhotau=40), @Meta.Rho(sigma=45, rhotau=63), @Meta.Rho(rhofun=false, rhotau=41),
-    @Meta.Rho(sigma=3, rhotau=65)
+    @Meta.Rho(rhofun=false, rhotau=30), @Meta.Rho(rhofun=false, rhotau=31), @Meta.Rho(rhofun=false, rhotau=32),
+    @Meta.Rho(sigma=39, rhotau=56), @Meta.Rho(rhofun=false, rhotau=33), @Meta.Rho(sigma=41, rhotau=11),
+    @Meta.Rho(rhofun=false, rhotau=36), @Meta.Rho(rhofun=false, rhotau=39), @Meta.Rho(rhofun=false, rhotau=40),
+    @Meta.Rho(rhofun=false, rhotau=41), @Meta.Rho(sigma=45, rhotau=63), @Meta.Rho(rhofun=false, rhotau=23),
+    @Meta.Rho(rhofun=false, rhotau=42), @Meta.Rho(sigma=47, rhotau=66), @Meta.Rho(sigma=3, rhotau=56)
   },
   sigmas={
     @Meta.Sigma(rho=0), @Meta.Sigma(rho=2), @Meta.Sigma(rho=3), @Meta.Sigma(rho=1), @Meta.Sigma(rho=5),
@@ -912,8 +917,9 @@ import frege.test.QuickCheckText;
     @Meta.Sigma(rho=37), @Meta.Sigma(bound={"α"}, kinds={12}, rho=38), @Meta.Sigma(rho=39), @Meta.Sigma(rho=41),
     @Meta.Sigma(rho=42), @Meta.Sigma(rho=44), @Meta.Sigma(rho=45), @Meta.Sigma(rho=47), @Meta.Sigma(rho=48),
     @Meta.Sigma(rho=49), @Meta.Sigma(rho=50), @Meta.Sigma(rho=51), @Meta.Sigma(rho=53), @Meta.Sigma(rho=54),
-    @Meta.Sigma(rho=55), @Meta.Sigma(rho=56), @Meta.Sigma(rho=57), @Meta.Sigma(rho=58), @Meta.Sigma(rho=59),
-    @Meta.Sigma(rho=61), @Meta.Sigma(rho=62), @Meta.Sigma(rho=64), @Meta.Sigma(rho=66)
+    @Meta.Sigma(rho=55), @Meta.Sigma(rho=57), @Meta.Sigma(rho=58), @Meta.Sigma(rho=59), @Meta.Sigma(rho=60),
+    @Meta.Sigma(rho=61), @Meta.Sigma(rho=62), @Meta.Sigma(rho=64), @Meta.Sigma(rho=65), @Meta.Sigma(rho=67),
+    @Meta.Sigma(rho=68)
   },
   exprs={@Meta.Expr()}
 )
@@ -947,14 +953,14 @@ final public static class IShow_Diagnostic implements PreludeText.CShow<TDiagnos
     return IShow_Diagnostic.showChars(arg$1.call());
   }
   final public static String/*<Character>*/ showsub(final TDiagnostic arg$1) {
-    final String/*<Character>*/ a4$17474 = arg$1.mem$message.call();
-    final String/*<Character>*/ a3$17473 = arg$1.mem$source.call();
-    final short a2$17472 = (short)arg$1.mem$severity.call();
-    final Range.TRange a1$17471 = arg$1.mem$range.call();
-    return ("(" + (((((((("Diagnostic" + " ") + Range.IShow_Range.showsub(a1$17471)) + " ") + IShow_DiagnosticSeverity.showsub(
-              a2$17472
-            )) + " ") + PreludeText.IShow_String.showsub(a3$17473)) + " ") + PreludeText.IShow_String.showsub(
-              a4$17474
+    final String/*<Character>*/ a4$17478 = arg$1.mem$message.call();
+    final String/*<Character>*/ a3$17477 = arg$1.mem$source.call();
+    final short a2$17476 = (short)arg$1.mem$severity.call();
+    final Range.TRange a1$17475 = arg$1.mem$range.call();
+    return ("(" + (((((((("Diagnostic" + " ") + Range.IShow_Range.showsub(a1$17475)) + " ") + IShow_DiagnosticSeverity.showsub(
+              a2$17476
+            )) + " ") + PreludeText.IShow_String.showsub(a3$17477)) + " ") + PreludeText.IShow_String.showsub(
+              a4$17478
             ))) + ")";
   }
   final public static String/*<Character>*/ showList(
@@ -963,9 +969,9 @@ final public static class IShow_Diagnostic implements PreludeText.CShow<TDiagnos
     return "[" + (PreludeText.joined(
               Thunk.<String/*<Character>*/>lazy(", "),
               PreludeList.<String/*<Character>*/, TDiagnostic>map(
-                    (Func.U<TDiagnostic, String/*<Character>*/>)((final Lazy<TDiagnostic> η$18677) -> Thunk.<
+                    (Func.U<TDiagnostic, String/*<Character>*/>)((final Lazy<TDiagnostic> η$18681) -> Thunk.<
                           String/*<Character>*/
-                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_Diagnostic.show(η$18677.call())))),
+                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_Diagnostic.show(η$18681.call())))),
                     arg$1
                   )
             ).call() + ("]" + arg$2));
@@ -1057,9 +1063,9 @@ final public static class IShow_DiagnosticSeverity implements PreludeText.CShow<
     return "[" + (PreludeText.joined(
               Thunk.<String/*<Character>*/>lazy(", "),
               PreludeList.<String/*<Character>*/, Short>map(
-                    (Func.U<Short, String/*<Character>*/>)((final Lazy<Short> η$18691) -> Thunk.<
+                    (Func.U<Short, String/*<Character>*/>)((final Lazy<Short> η$18695) -> Thunk.<
                           String/*<Character>*/
-                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_DiagnosticSeverity.show((short)η$18691.call())))),
+                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_DiagnosticSeverity.show((short)η$18695.call())))),
                     arg$1
                   )
             ).call() + ("]" + arg$2));
@@ -1220,19 +1226,19 @@ final public static class TDiagnostic implements frege.runtime.Value, Lazy<TDiag
     return TDiagnostic.mk(arg$1.mem$range, arg$2, arg$1.mem$source, arg$1.mem$message);
   }
   final public static String/*<Character>*/ source(final TDiagnostic arg$1) {
-    final String/*<Character>*/ a3$17394 = arg$1.mem$source.call();
-    return a3$17394;
+    final String/*<Character>*/ a3$17395 = arg$1.mem$source.call();
+    return a3$17395;
   }
   final public static TDiagnostic upd$message(final TDiagnostic arg$1, final Lazy<String/*<Character>*/> arg$2) {
     return TDiagnostic.mk(arg$1.mem$range, arg$1.mem$severity, arg$1.mem$source, arg$2);
   }
   final public static Range.TRange range(final TDiagnostic arg$1) {
-    final Range.TRange a1$17356 = arg$1.mem$range.call();
-    return a1$17356;
+    final Range.TRange a1$17357 = arg$1.mem$range.call();
+    return a1$17357;
   }
   final public static short severity(final TDiagnostic arg$1) {
-    final short a2$17375 = (short)arg$1.mem$severity.call();
-    return a2$17375;
+    final short a2$17376 = (short)arg$1.mem$severity.call();
+    return a2$17376;
   }
   final public static <α> boolean has$source(final Lazy<α> arg$1) {
     return true;
@@ -1280,8 +1286,8 @@ final public static class TDiagnostic implements frege.runtime.Value, Lazy<TDiag
     return true;
   }
   final public static String/*<Character>*/ message(final TDiagnostic arg$1) {
-    final String/*<Character>*/ a4$17341 = arg$1.mem$message.call();
-    return a4$17341;
+    final String/*<Character>*/ a4$17342 = arg$1.mem$message.call();
+    return a4$17342;
   }
 }
 final public static class TDiagnosticSeverity  {
@@ -1291,40 +1297,40 @@ final public static class TDiagnosticSeverity  {
   final public static short INFORMATION = 2;
 }
 final public static Range.TRange tokensToRange(final PreludeBase.TList<Tokens.TToken> arg$1) {
-  final PreludeBase.TList.DList<Tokens.TToken> $18718 = arg$1.asList();
-  if ($18718 != null) {
+  final PreludeBase.TList.DList<Tokens.TToken> $18722 = arg$1.asList();
+  if ($18722 != null) {
     return Range.TRange.mk(
               Position.TPosition.mk(Thunk.<Integer>lazy(1), Thunk.<Integer>lazy(0)),
               Position.TPosition.mk(Thunk.<Integer>lazy(2), Thunk.<Integer>lazy(0))
             );
   }
-  final PreludeBase.TList.DCons<Tokens.TToken> $18719 = arg$1.asCons();
-  if ($18719 != null) {
-    final PreludeBase.TList<Tokens.TToken> $18720 = $18719.mem2.call();
-    final PreludeBase.TList.DList<Tokens.TToken> $18721 = $18720.asList();
-    if ($18721 != null) {
-      final Tokens.TToken tk$17410 = $18719.mem1.call();
-      return Range.tokenToRange(tk$17410);
+  final PreludeBase.TList.DCons<Tokens.TToken> $18723 = arg$1.asCons();
+  if ($18723 != null) {
+    final PreludeBase.TList<Tokens.TToken> $18724 = $18723.mem2.call();
+    final PreludeBase.TList.DList<Tokens.TToken> $18725 = $18724.asList();
+    if ($18725 != null) {
+      final Tokens.TToken tk$17411 = $18723.mem1.call();
+      return Range.tokenToRange(tk$17411);
     }
   }
-  final Lazy<Tokens.TToken> endToken$17413 = Thunk.<Tokens.TToken>shared(
+  final Lazy<Tokens.TToken> endToken$17414 = Thunk.<Tokens.TToken>shared(
         (Lazy<Tokens.TToken>)(() -> PreludeList.<Tokens.TToken>last(arg$1))
       );
-  final Lazy<Tokens.TToken> startToken$17412 = Thunk.<Tokens.TToken>shared(
+  final Lazy<Tokens.TToken> startToken$17413 = Thunk.<Tokens.TToken>shared(
         (Lazy<Tokens.TToken>)(() -> PreludeList.IListView_$lbrack$rbrack.<Tokens.TToken>head(
                   arg$1
                 ))
       );
   return Range.TRange.mk(
             Position.TPosition.mk(
-                  Thunk.<Integer>lazy(Tokens.TToken.line(startToken$17412.call())),
-                  Thunk.<Integer>lazy(Tokens.TToken.col(startToken$17412.call()))
+                  Thunk.<Integer>lazy(Tokens.TToken.line(startToken$17413.call())),
+                  Thunk.<Integer>lazy(Tokens.TToken.col(startToken$17413.call()))
                 ),
             Position.TPosition.mk(
-                  Thunk.<Integer>lazy(Tokens.TToken.line(endToken$17413.call())),
+                  Thunk.<Integer>lazy(Tokens.TToken.line(endToken$17414.call())),
                   Thunk.<Integer>shared(
-                        (Lazy<Integer>)(() -> Tokens.TToken.col(endToken$17413.call()) + Tokens.TToken.value(
-                                  endToken$17413.call()
+                        (Lazy<Integer>)(() -> Tokens.TToken.col(endToken$17414.call()) + Tokens.TToken.value(
+                                  endToken$17414.call()
                                 ).length())
                       )
                 )
@@ -1333,61 +1339,61 @@ final public static Range.TRange tokensToRange(final PreludeBase.TList<Tokens.TT
 final public static PreludeBase.TList<Tokens.TToken> posToTokens(
   final PreludeBase.TList<Positions.TPosition> arg$1, final Lazy<Global.TGlobal> arg$2
 ) {
-  final PreludeBase.TList.DCons<Positions.TPosition> $18723 = arg$1.asCons();
-  if ($18723 != null) {
-    final Positions.TPosition µ$$17531 = $18723.mem1.call();
+  final PreludeBase.TList.DCons<Positions.TPosition> $18727 = arg$1.asCons();
+  if ($18727 != null) {
+    final Positions.TPosition µ$$17535 = $18727.mem1.call();
     return PreludeList.IListMonoid_$lbrack$rbrack.<Tokens.TToken>$plus$plus(
-              Global.tokens(µ$$17531, arg$2),
+              Global.tokens(µ$$17535, arg$2),
               Thunk.<PreludeBase.TList<Tokens.TToken>>shared(
                     (Lazy<PreludeBase.TList<Tokens.TToken>>)(() -> Diagnostic.posToTokens(
-                              $18723.mem2.call(), arg$2
+                              $18727.mem2.call(), arg$2
                             ))
                   )
             );
   }
-  final PreludeBase.TList.DList<Positions.TPosition> $18725 = arg$1.asList();
-  assert $18725 != null;
+  final PreludeBase.TList.DList<Positions.TPosition> $18729 = arg$1.asList();
+  assert $18729 != null;
   return PreludeBase.TList.DList.<Tokens.TToken>mk();
 }
 final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWorld, Short>>shared(
       (Lazy<Func.U<RealWorld, Short>>)(() -> {
-            return (Func.U<RealWorld, Short>)((final Lazy<RealWorld> arg$18726) -> {
-                      final Global.TGlobal v2056$18280 = CompileExecutor.compile(
+            return (Func.U<RealWorld, Short>)((final Lazy<RealWorld> arg$18730) -> {
+                      final Global.TGlobal v2056$18299 = CompileExecutor.compile(
                             Thunk.<String/*<Character>*/>lazy(
                                   "module FaultyFregeTest where\n\nsimplyString s = s\n\nerr1 = (simplyString 42) ++ \"test\""
                                 ),
                             CompileGlobal.standardCompileGlobal.call()
-                          ).apply(arg$18726).call();
-                      final Func.U<RealWorld, Short> v4793$18302 = Prelude.<String/*<Character>*/>println(
-                            PreludeText.IShow_String.it, Global.TSubSt.code(Global.TGlobal.sub(v2056$18280)).toString()
+                          ).apply(arg$18730).call();
+                      final Func.U<RealWorld, Short> v4793$18321 = Prelude.<String/*<Character>*/>println(
+                            PreludeText.IShow_String.it, Global.TSubSt.code(Global.TGlobal.sub(v2056$18299)).toString()
                           );
-                      final short v4796$18304 = (short)v4793$18302.apply(arg$18726).call();
-                      final Func.U<RealWorld, Short> v4797$18305 = ((Func.U<RealWorld, Short>)((
-                        final Lazy<RealWorld> arg$18731
+                      final short v4796$18323 = (short)v4793$18321.apply(arg$18730).call();
+                      final Func.U<RealWorld, Short> v4797$18324 = ((Func.U<RealWorld, Short>)((
+                        final Lazy<RealWorld> arg$18735
                       ) -> {
-                            final short v4796$18335 = (short)Func.<RealWorld, Short>coerceU(
+                            final short v4796$18354 = (short)Func.<RealWorld, Short>coerceU(
                                   PreludeMonad.<Func.U<RealWorld, ?>, Global.TMessage, Short, PreludeBase.TList<?>>$for(
                                         PreludeMonad.IMonad_ST.<RealWorld>mk(),
                                         PreludeList.IListSource_$lbrack$rbrack.<PreludeBase.TList<?>>mk(),
                                         Thunk.<Kind.U<PreludeBase.TList<?>, Global.TMessage>>lazy(
                                               (Kind.U<PreludeBase.TList<?>, Global.TMessage>)Global.TSubSt.messages(
-                                                    Global.TGlobal.sub(v2056$18280)
+                                                    Global.TGlobal.sub(v2056$18299)
                                                   )
                                             ),
                                         (Func.U<Global.TMessage, Kind.U<Func.U<RealWorld, ?>, Short>>)((
-                                          final Lazy<Global.TMessage> η$18730
+                                          final Lazy<Global.TMessage> η$18734
                                         ) -> Thunk.<Kind.U<Func.U<RealWorld, ?>, Short>>shared(
                                                   (Lazy<Kind.U<Func.U<RealWorld, ?>, Short>>)(() -> (Kind.U<
                                                         Func.U<RealWorld, ?>, Short
                                                       >)Thunk.<Func.U<RealWorld, Short>>shared(
                                                             (Lazy<Func.U<RealWorld, Short>>)(() -> Prelude.<
                                                                   Global.TMessage
-                                                                >println(CompileExecutor.IShow_Message.it, η$18730.call()))
+                                                                >println(CompileExecutor.IShow_Message.it, η$18734.call()))
                                                           ).call())
                                                 ))
                                       )
-                                ).apply(arg$18731).call();
-                            final Func.U<RealWorld, Short> v4797$18336 = Thunk.<Func.U<RealWorld, Short>>shared(
+                                ).apply(arg$18735).call();
+                            final Func.U<RealWorld, Short> v4797$18355 = Thunk.<Func.U<RealWorld, Short>>shared(
                                   (Lazy<Func.U<RealWorld, Short>>)(() -> Func.<RealWorld, Short>coerceU(
                                             Thunk.<Kind.U<Func.U<RealWorld, ?>, Short>>shared(
                                                   (Lazy<Kind.U<Func.U<RealWorld, ?>, Short>>)(() -> PreludeMonad.<
@@ -1417,23 +1423,23 @@ final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWor
                                                                                               Global.TMessage,
                                                                                               Positions.TPosition
                                                                                             >)((
-                                                                                              final Lazy<Global.TMessage> η$18728
+                                                                                              final Lazy<Global.TMessage> η$18732
                                                                                             ) -> Global.TMessage.pos(
-                                                                                                      η$18728
+                                                                                                      η$18732
                                                                                                       .call()
                                                                                                     )),
                                                                                             Global.TSubSt.messages(
                                                                                                   Global.TGlobal.sub(
-                                                                                                        v2056$18280
+                                                                                                        v2056$18299
                                                                                                       )
                                                                                                 )
                                                                                           ),
-                                                                                      v2056$18280
+                                                                                      v2056$18299
                                                                                     ))
                                                                           ).call())
                                                                 ),
                                                             (Func.U<Tokens.TToken, Kind.U<Func.U<RealWorld, ?>, Short>>)((
-                                                              final Lazy<Tokens.TToken> η$18729
+                                                              final Lazy<Tokens.TToken> η$18733
                                                             ) -> Thunk.<Kind.U<Func.U<RealWorld, ?>, Short>>shared(
                                                                       (Lazy<Kind.U<Func.U<RealWorld, ?>, Short>>)(() -> (Kind.U<
                                                                             Func.U<RealWorld, ?>, Short
@@ -1444,7 +1450,7 @@ final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWor
                                                                                       Tokens.TToken
                                                                                     >println(
                                                                                           Tokens.IShow_Token.it,
-                                                                                          η$18729
+                                                                                          η$18733
                                                                                           .call()
                                                                                         ))
                                                                               ).call())
@@ -1453,9 +1459,9 @@ final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWor
                                                 ).call()
                                           ))
                                 ).call();
-                            return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$18336.apply(arg$18731)));
+                            return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$18355.apply(arg$18735)));
                           })).call();
-                      return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$18305.apply(arg$18726)));
+                      return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$18324.apply(arg$18730)));
                     });
           })
     );
@@ -1472,16 +1478,16 @@ final public static short fromCompilerSeverity(final short arg$1) {
 final public static State.TState<Global.TGlobal, Range.TRange> createRangeFromPos(final Positions.TPosition arg$1) {
   return State.TState.<Global.TGlobal, Range.TRange>mk(
             (Func.U<Global.TGlobal, PreludeBase.TTuple2<Range.TRange, Global.TGlobal>>)((
-              final Lazy<Global.TGlobal> arg$18737
+              final Lazy<Global.TGlobal> arg$18741
             ) -> {
-                  final State.TState<Global.TGlobal, Range.TRange> $18738 = State.IMonad_State.<
+                  final State.TState<Global.TGlobal, Range.TRange> $18742 = State.IMonad_State.<
                     Global.TGlobal, Range.TRange
-                  >pure(Diagnostic.tokensToRange(Global.tokens(arg$1, arg$18737)));
-                  final Func.U<Global.TGlobal, PreludeBase.TTuple2<Range.TRange, Global.TGlobal>> v7693$18580 =
-                  $18738.mem$fun;
+                  >pure(Diagnostic.tokensToRange(Global.tokens(arg$1, arg$18741)));
+                  final Func.U<Global.TGlobal, PreludeBase.TTuple2<Range.TRange, Global.TGlobal>> v7693$18584 =
+                  $18742.mem$fun;
                   return Thunk.<PreludeBase.TTuple2<Range.TRange, Global.TGlobal>>nested(
-                            (Lazy<Lazy<PreludeBase.TTuple2<Range.TRange, Global.TGlobal>>>)(() -> v7693$18580
-                                .apply(arg$18737))
+                            (Lazy<Lazy<PreludeBase.TTuple2<Range.TRange, Global.TGlobal>>>)(() -> v7693$18584
+                                .apply(arg$18741))
                           );
                 })
           );
@@ -1489,22 +1495,22 @@ final public static State.TState<Global.TGlobal, Range.TRange> createRangeFromPo
 final public static State.TState<Global.TGlobal, TDiagnostic> createDiagnosticFromMessage(
   final Global.TMessage arg$1
 ) {
-  final State.TState<Global.TGlobal, Range.TRange> $18740 = Diagnostic.createRangeFromPos(
+  final State.TState<Global.TGlobal, Range.TRange> $18744 = Diagnostic.createRangeFromPos(
         Global.TMessage.pos(arg$1)
       );
-  final Func.U<Global.TGlobal, PreludeBase.TTuple2<Range.TRange, Global.TGlobal>> v7688$18542 =
-  $18740.mem$fun;
+  final Func.U<Global.TGlobal, PreludeBase.TTuple2<Range.TRange, Global.TGlobal>> v7688$18546 =
+  $18744.mem$fun;
   return State.TState.<Global.TGlobal, TDiagnostic>mk(
             (Func.U<Global.TGlobal, PreludeBase.TTuple2<TDiagnostic, Global.TGlobal>>)((
-              final Lazy<Global.TGlobal> arg$18742
+              final Lazy<Global.TGlobal> arg$18746
             ) -> {
-                  final PreludeBase.TTuple2<Range.TRange, Global.TGlobal> $18743 = v7688$18542
-                  .apply(arg$18742).call();
-                  final State.TState<Global.TGlobal, TDiagnostic> $18744 = State.IMonad_State.<
+                  final PreludeBase.TTuple2<Range.TRange, Global.TGlobal> $18747 = v7688$18546
+                  .apply(arg$18746).call();
+                  final State.TState<Global.TGlobal, TDiagnostic> $18748 = State.IMonad_State.<
                     Global.TGlobal, TDiagnostic
                   >pure(
                         TDiagnostic.mk(
-                              $18743.mem1,
+                              $18747.mem1,
                               Thunk.<Short>shared(
                                     (Lazy<Short>)(() -> Diagnostic.fromCompilerSeverity(
                                               Global.TMessage.level(arg$1)
@@ -1514,11 +1520,11 @@ final public static State.TState<Global.TGlobal, TDiagnostic> createDiagnosticFr
                               Thunk.<String/*<Character>*/>lazy(Global.TMessage.text(arg$1))
                             )
                       );
-                  final Func.U<Global.TGlobal, PreludeBase.TTuple2<TDiagnostic, Global.TGlobal>> v7693$18547 =
-                  $18744.mem$fun;
+                  final Func.U<Global.TGlobal, PreludeBase.TTuple2<TDiagnostic, Global.TGlobal>> v7693$18551 =
+                  $18748.mem$fun;
                   return Thunk.<PreludeBase.TTuple2<TDiagnostic, Global.TGlobal>>nested(
-                            (Lazy<Lazy<PreludeBase.TTuple2<TDiagnostic, Global.TGlobal>>>)(() -> v7693$18547
-                                .apply($18743.mem2))
+                            (Lazy<Lazy<PreludeBase.TTuple2<TDiagnostic, Global.TGlobal>>>)(() -> v7693$18551
+                                .apply($18747.mem2))
                           );
                 })
           );
@@ -1526,53 +1532,52 @@ final public static State.TState<Global.TGlobal, TDiagnostic> createDiagnosticFr
 final public static State.TState<Global.TGlobal, PreludeBase.TList<TDiagnostic>> extractDiagnostics =
 State.TState.<Global.TGlobal, PreludeBase.TList<TDiagnostic>>mk(
       (Func.U<Global.TGlobal, PreludeBase.TTuple2<PreludeBase.TList<TDiagnostic>, Global.TGlobal>>)((
-        final Lazy<Global.TGlobal> arg$18746
+        final Lazy<Global.TGlobal> arg$18750
       ) -> {
-            final Global.TGlobal v7690$18509 = arg$18746.call();
-            final State.TState<Global.TGlobal, PreludeBase.TList<TDiagnostic>> $18749 =
+            final Global.TGlobal v7690$18513 = arg$18750.call();
+            final State.TState<Global.TGlobal, PreludeBase.TList<TDiagnostic>> $18753 =
             State.TState.<Global.TGlobal, PreludeBase.TList<TDiagnostic>>coerce(
                   PreludeMonad.<State.TState<Global.TGlobal, ?>, TDiagnostic>sequence(
                         State.IMonad_State.<Global.TGlobal>mk(), State.IMonad_State.<Global.TGlobal>mk(),
                         PreludeMonad.IFunctor_$lbrack$rbrack.<Global.TMessage, State.TState<Global.TGlobal, TDiagnostic>>fmap(
                               (Func.U<Global.TMessage, State.TState<Global.TGlobal, TDiagnostic>>)((
-                                final Lazy<Global.TMessage> η$18748
+                                final Lazy<Global.TMessage> η$18752
                               ) -> Thunk.<State.TState<Global.TGlobal, TDiagnostic>>shared(
                                         (Lazy<State.TState<
                                           Global.TGlobal, TDiagnostic
                                         >>)(() -> Diagnostic.createDiagnosticFromMessage(
-                                                  η$18748.call()
+                                                  η$18752.call()
                                                 ))
                                       )),
-                              Global.TSubSt.messages(Global.TGlobal.sub(v7690$18509))
+                              Global.TSubSt.messages(Global.TGlobal.sub(v7690$18513))
                             ).<Kind.U<State.TState<Global.TGlobal, ?>, TDiagnostic>>simsalabim()
                       )
                 );
-            final Func.U<Global.TGlobal, PreludeBase.TTuple2<PreludeBase.TList<TDiagnostic>, Global.TGlobal>> v7693$18512 =
-            $18749.mem$fun;
+            final Func.U<Global.TGlobal, PreludeBase.TTuple2<PreludeBase.TList<TDiagnostic>, Global.TGlobal>> v7693$18516 =
+            $18753.mem$fun;
             return Thunk.<PreludeBase.TTuple2<PreludeBase.TList<TDiagnostic>, Global.TGlobal>>nested(
-                      (Lazy<Lazy<PreludeBase.TTuple2<PreludeBase.TList<TDiagnostic>, Global.TGlobal>>>)(() -> v7693$18512
-                          .apply(v7690$18509))
+                      (Lazy<Lazy<PreludeBase.TTuple2<PreludeBase.TList<TDiagnostic>, Global.TGlobal>>>)(() -> v7693$18516
+                          .apply(v7690$18513))
                     );
           })
     );
-final public static Func.U<RealWorld, PreludeBase.TList<TDiagnostic>> compileAndGetDiagnostics(
-  final Lazy<String/*<Character>*/> arg$1
+final public static Func.U<RealWorld, PreludeBase.TList<TDiagnostic>> getDiagnostics(
+  final Func.U<RealWorld, Global.TGlobal> arg$1
 ) {
-  return (Func.U<RealWorld, PreludeBase.TList<TDiagnostic>>)((final Lazy<RealWorld> arg$18751) -> {
-            final Global.TGlobal v2056$18619 = CompileExecutor.compile(arg$1, CompileGlobal.standardCompileGlobal.call())
-            .apply(arg$18751).call();
-            final Func.U<RealWorld, PreludeBase.TList<TDiagnostic>> v2057$18620 = PreludeMonad.IMonad_ST.<
+  return (Func.U<RealWorld, PreludeBase.TList<TDiagnostic>>)((final Lazy<RealWorld> arg$18755) -> {
+            final Global.TGlobal v2056$18376 = arg$1.apply(arg$18755).call();
+            final Func.U<RealWorld, PreludeBase.TList<TDiagnostic>> v2057$18377 = PreludeMonad.IMonad_ST.<
               RealWorld, PreludeBase.TList<TDiagnostic>
             >pure(
                   Thunk.<PreludeBase.TList<TDiagnostic>>shared(
                         (Lazy<PreludeBase.TList<TDiagnostic>>)(() -> State.<
                               Global.TGlobal, PreludeBase.TList<TDiagnostic>
-                            >evalState(Diagnostic.extractDiagnostics, v2056$18619))
+                            >evalState(Diagnostic.extractDiagnostics, v2056$18376))
                       )
                 );
             return Thunk.<PreludeBase.TList<TDiagnostic>>nested(
-                      (Lazy<Lazy<PreludeBase.TList<TDiagnostic>>>)(() -> v2057$18620.apply(
-                                arg$18751
+                      (Lazy<Lazy<PreludeBase.TList<TDiagnostic>>>)(() -> v2057$18377.apply(
+                                arg$18755
                               ))
                     );
           });
@@ -1592,18 +1597,18 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$18754) -> {
-                                            final Global.TGlobal v2056$18364 = CompileGlobal.standardCompileGlobal
-                                            .call().apply(arg$18754).call();
-                                            final Func.U<RealWorld, PreludeBase.TList<TDiagnostic>> v2053$18383 =
-                                            Diagnostic.compileAndGetDiagnostics(
-                                                  Thunk.<String/*<Character>*/>lazy(
-                                                        "module ch.fhnw.thga.FaultyFregeTest where\n\nimport Does.not.Exist"
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$18758) -> {
+                                            final PreludeBase.TList<TDiagnostic> v2056$18412 =
+                                            Diagnostic.getDiagnostics(
+                                                  CompileExecutor.compile(
+                                                        Thunk.<String/*<Character>*/>lazy(
+                                                              "module ch.fhnw.thga.FaultyFregeTest where\n\nimport Does.not.Exist"
+                                                            ),
+                                                        CompileGlobal.standardCompileGlobal
+                                                        .call()
                                                       )
-                                                );
-                                            final PreludeBase.TList<TDiagnostic> v2056$18386 =
-                                            v2053$18383.apply(arg$18754).call();
-                                            final Func.U<RealWorld, Boolean> v2057$18387 =
+                                                ).apply(arg$18758).call();
+                                            final Func.U<RealWorld, Boolean> v2057$18413 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> PreludeBase.IEq_$lbrack$rbrack.<
@@ -1654,13 +1659,13 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                           TDiagnostic
                                                                         >mk()
                                                                       ),
-                                                                  v2056$18386
+                                                                  v2056$18412
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18387
-                                                          .apply(arg$18754))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18413
+                                                          .apply(arg$18758))
                                                     );
                                           })
                                     ))
@@ -1683,29 +1688,33 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$18759) -> {
-                                            final PreludeBase.TList<TDiagnostic> v2056$18480 =
-                                            Diagnostic.compileAndGetDiagnostics(
-                                                  Thunk.<String/*<Character>*/>shared(
-                                                        (Lazy<String/*
-                                                          <Character>
-                                                        */>)(() -> "module CorrectFregeTest where\n\n" + "ok = 42 + 42")
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$18761) -> {
+                                            final PreludeBase.TList<TDiagnostic> v2056$18484 =
+                                            Diagnostic.getDiagnostics(
+                                                  CompileExecutor.compile(
+                                                        Thunk.<String/*<Character>*/>shared(
+                                                              (Lazy<String/*
+                                                                <Character>
+                                                              */>)(() -> "module CorrectFregeTest where\n\n" + "ok = 42 + 42")
+                                                            ),
+                                                        CompileGlobal.standardCompileGlobal
+                                                        .call()
                                                       )
-                                                ).apply(arg$18759).call();
-                                            final Func.U<RealWorld, Boolean> v2057$18481 =
+                                                ).apply(arg$18761).call();
+                                            final Func.U<RealWorld, Boolean> v2057$18485 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> PreludeBase.IEq_$lbrack$rbrack.<
                                                               TDiagnostic
                                                             >$eq$eq(
                                                                   IEq_Diagnostic.it, PreludeBase.TList.DList.<TDiagnostic>mk(),
-                                                                  v2056$18480
+                                                                  v2056$18484
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18481
-                                                          .apply(arg$18759))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18485
+                                                          .apply(arg$18761))
                                                     );
                                           })
                                     ))
@@ -1728,18 +1737,18 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$18762) -> {
-                                            final Global.TGlobal v2056$18422 = CompileGlobal.standardCompileGlobal
-                                            .call().apply(arg$18762).call();
-                                            final Func.U<RealWorld, PreludeBase.TList<TDiagnostic>> v2053$18441 =
-                                            Diagnostic.compileAndGetDiagnostics(
-                                                  Thunk.<String/*<Character>*/>lazy(
-                                                        "module ch.fhnw.thga.FaultyFregeTest where\n\nerr1 = do\n  x = 42\n\nerr2 = [ 22.0 ] ++ \"42\"\n\nerr3 = 42 + \"42\""
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$18764) -> {
+                                            final PreludeBase.TList<TDiagnostic> v2056$18448 =
+                                            Diagnostic.getDiagnostics(
+                                                  CompileExecutor.compile(
+                                                        Thunk.<String/*<Character>*/>lazy(
+                                                              "module ch.fhnw.thga.FaultyFregeTest where\n\nerr1 = do\n  x = 42\n\nerr2 = [ 22.0 ] ++ \"42\"\n\nerr3 = 42 + \"42\""
+                                                            ),
+                                                        CompileGlobal.standardCompileGlobal
+                                                        .call()
                                                       )
-                                                );
-                                            final PreludeBase.TList<TDiagnostic> v2056$18444 =
-                                            v2053$18441.apply(arg$18762).call();
-                                            final Func.U<RealWorld, Boolean> v2057$18445 =
+                                                ).apply(arg$18764).call();
+                                            final Func.U<RealWorld, Boolean> v2057$18449 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> PreludeBase.IEq_$lbrack$rbrack.<
@@ -1900,13 +1909,13 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                                   )
                                                                             )
                                                                       ),
-                                                                  v2056$18444
+                                                                  v2056$18448
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18445
-                                                          .apply(arg$18762))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18449
+                                                          .apply(arg$18764))
                                                     );
                                           })
                                     ))
@@ -1914,6 +1923,28 @@ final public static Lazy<QuickCheckGen.TGen<
                     );
           })
     );
+final public static Func.U<RealWorld, PreludeBase.TList<TDiagnostic>> compileAndGetDiagnostics(
+  final Lazy<String/*<Character>*/> arg$1
+) {
+  return (Func.U<RealWorld, PreludeBase.TList<TDiagnostic>>)((final Lazy<RealWorld> arg$18767) -> {
+            final Global.TGlobal v2056$18623 = CompileExecutor.compile(arg$1, CompileGlobal.standardCompileGlobal.call())
+            .apply(arg$18767).call();
+            final Func.U<RealWorld, PreludeBase.TList<TDiagnostic>> v2057$18624 = PreludeMonad.IMonad_ST.<
+              RealWorld, PreludeBase.TList<TDiagnostic>
+            >pure(
+                  Thunk.<PreludeBase.TList<TDiagnostic>>shared(
+                        (Lazy<PreludeBase.TList<TDiagnostic>>)(() -> State.<
+                              Global.TGlobal, PreludeBase.TList<TDiagnostic>
+                            >evalState(Diagnostic.extractDiagnostics, v2056$18623))
+                      )
+                );
+            return Thunk.<PreludeBase.TList<TDiagnostic>>nested(
+                      (Lazy<Lazy<PreludeBase.TList<TDiagnostic>>>)(() -> v2057$18624.apply(
+                                arg$18767
+                              ))
+                    );
+          });
+}
 
   public static void main(final java.lang.String[] argv) {
     try {

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.java
@@ -947,14 +947,14 @@ final public static class IShow_Diagnostic implements PreludeText.CShow<TDiagnos
     return IShow_Diagnostic.showChars(arg$1.call());
   }
   final public static String/*<Character>*/ showsub(final TDiagnostic arg$1) {
-    final String/*<Character>*/ a4$17476 = arg$1.mem$message.call();
-    final String/*<Character>*/ a3$17475 = arg$1.mem$source.call();
-    final short a2$17474 = (short)arg$1.mem$severity.call();
-    final Range.TRange a1$17473 = arg$1.mem$range.call();
-    return ("(" + (((((((("Diagnostic" + " ") + Range.IShow_Range.showsub(a1$17473)) + " ") + IShow_DiagnosticSeverity.showsub(
-              a2$17474
-            )) + " ") + PreludeText.IShow_String.showsub(a3$17475)) + " ") + PreludeText.IShow_String.showsub(
-              a4$17476
+    final String/*<Character>*/ a4$17474 = arg$1.mem$message.call();
+    final String/*<Character>*/ a3$17473 = arg$1.mem$source.call();
+    final short a2$17472 = (short)arg$1.mem$severity.call();
+    final Range.TRange a1$17471 = arg$1.mem$range.call();
+    return ("(" + (((((((("Diagnostic" + " ") + Range.IShow_Range.showsub(a1$17471)) + " ") + IShow_DiagnosticSeverity.showsub(
+              a2$17472
+            )) + " ") + PreludeText.IShow_String.showsub(a3$17473)) + " ") + PreludeText.IShow_String.showsub(
+              a4$17474
             ))) + ")";
   }
   final public static String/*<Character>*/ showList(
@@ -987,6 +987,28 @@ final public static class IShow_Diagnostic implements PreludeText.CShow<TDiagnos
               a2$17469
             )) + " ") + PreludeText.IShow_String.showsub(a3$17470)) + " ") + PreludeText.IShow_String.showsub(
               a4$17471
+            );
+  }
+  final public static PreludeBase.TList<Character> showChars(final TDiagnostic arg$1) {
+    return PreludeList.IListView_StringJ.<Character>toList(IShow_Diagnostic.show(arg$1));
+  }
+  final public static String/*<Character>*/ showsPrec(
+    final Lazy<Integer> arg$1, final TDiagnostic arg$2, final String/*<Character>*/ arg$3
+  ) {
+    return IShow_Diagnostic.show(arg$2) + arg$3;
+  }
+  final public static String/*<Character>*/ display(final TDiagnostic arg$1) {
+    return IShow_Diagnostic.show(arg$1);
+  }
+  final public static String/*<Character>*/ show(final TDiagnostic arg$1) {
+    final String/*<Character>*/ a4$17469 = arg$1.mem$message.call();
+    final String/*<Character>*/ a3$17468 = arg$1.mem$source.call();
+    final short a2$17467 = (short)arg$1.mem$severity.call();
+    final Range.TRange a1$17466 = arg$1.mem$range.call();
+    return ((((((("Diagnostic" + " ") + Range.IShow_Range.showsub(a1$17466)) + " ") + IShow_DiagnosticSeverity.showsub(
+              a2$17467
+            )) + " ") + PreludeText.IShow_String.showsub(a3$17468)) + " ") + PreludeText.IShow_String.showsub(
+              a4$17469
             );
   }
   final public static PreludeBase.TList<Character> showChars(final TDiagnostic arg$1) {
@@ -1315,7 +1337,7 @@ final public static PreludeBase.TList<Tokens.TToken> posToTokens(
   if ($18723 != null) {
     final Positions.TPosition µ$$17531 = $18723.mem1.call();
     return PreludeList.IListMonoid_$lbrack$rbrack.<Tokens.TToken>$plus$plus(
-              Global.tokens(µ$$17533, arg$2),
+              Global.tokens(µ$$17531, arg$2),
               Thunk.<PreludeBase.TList<Tokens.TToken>>shared(
                     (Lazy<PreludeBase.TList<Tokens.TToken>>)(() -> Diagnostic.posToTokens(
                               $18723.mem2.call(), arg$2

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.java
@@ -143,7 +143,7 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.fr",
-  time=1658602830795L, jmajor=11, jminor=-1,
+  time=1658948164070L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", "frege.compiler.types.Global", "frege.Prelude",
     "frege.prelude.PreludeArrays", "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal",
@@ -157,14 +157,14 @@ import frege.test.QuickCheckText;
   symas={}, symcs={}, symis={},
   symts={
     @Meta.SymT(
-      offset=365,
+      offset=339,
       name=@Meta.QName(
         kind=0, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="DiagnosticSeverityLSP"
       ),
       typ=0, kind=2, cons={}, lnks={},
       funs={
         @Meta.SymV(
-          offset=564,
+          offset=538,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="DiagnosticSeverityLSP",
             member="warning"
@@ -173,7 +173,7 @@ import frege.test.QuickCheckText;
           depth=0, rkind=9
         ),
         @Meta.SymV(
-          offset=772,
+          offset=746,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="DiagnosticSeverityLSP",
             member="hint"
@@ -182,7 +182,7 @@ import frege.test.QuickCheckText;
           rkind=9
         ),
         @Meta.SymV(
-          offset=460,
+          offset=434,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="DiagnosticSeverityLSP",
             member="error"
@@ -191,7 +191,7 @@ import frege.test.QuickCheckText;
           rkind=9
         ),
         @Meta.SymV(
-          offset=865,
+          offset=839,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="DiagnosticSeverityLSP",
             member="fromCompilerSeverity"
@@ -199,7 +199,7 @@ import frege.test.QuickCheckText;
           stri="s(s)", sig=2, depth=1, rkind=13
         ),
         @Meta.SymV(
-          offset=668,
+          offset=642,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="DiagnosticSeverityLSP",
             member="information"
@@ -211,12 +211,12 @@ import frege.test.QuickCheckText;
       pur=true, nativ="org.eclipse.lsp4j.DiagnosticSeverity"
     ),
     @Meta.SymT(
-      offset=1145,
+      offset=1119,
       name=@Meta.QName(kind=0, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="DiagnosticLSP"),
       typ=3, kind=2, cons={}, lnks={},
       funs={
         @Meta.SymV(
-          offset=1307,
+          offset=1281,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="DiagnosticLSP",
             member="fromDiagnostic"
@@ -224,7 +224,7 @@ import frege.test.QuickCheckText;
           stri="s(s(ssss))", sig=5, depth=1, rkind=13
         ),
         @Meta.SymV(
-          offset=1224,
+          offset=1198,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="DiagnosticLSP",
             member="new"
@@ -235,12 +235,12 @@ import frege.test.QuickCheckText;
       pur=true, nativ="org.eclipse.lsp4j.Diagnostic"
     ),
     @Meta.SymT(
-      offset=1588,
+      offset=1562,
       name=@Meta.QName(kind=0, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="ArrayList"),
       typ=9, kind=24, cons={}, lnks={},
       funs={
         @Meta.SymV(
-          offset=1702,
+          offset=1676,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="ArrayList",
             member="new"
@@ -248,7 +248,7 @@ import frege.test.QuickCheckText;
           stri="s(s)", sig=11, nativ="new", depth=1, rkind=9
         ),
         @Meta.SymV(
-          offset=1644,
+          offset=1618,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="ArrayList",
             member="add"
@@ -256,7 +256,7 @@ import frege.test.QuickCheckText;
           stri="s(ss)", sig=14, nativ="add", depth=2, rkind=9
         ),
         @Meta.SymV(
-          offset=1744,
+          offset=1718,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="ArrayList",
             member="fromFregeList"
@@ -269,15 +269,12 @@ import frege.test.QuickCheckText;
   },
   symvs={
     @Meta.SymV(
-      offset=2008,
-      name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="getDiagnosticsLSP"),
-      stri="s(s)", sig=18, depth=1, rkind=13
+      offset=2234, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="main"),
+      stri="u", sig=17, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=2261,
-      name=@Meta.QName(
-        pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="compileAndGetDiagnosticsLSP"
-      ),
+      offset=1982,
+      name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="getDiagnosticsLSP"),
       stri="s(u)", sig=19, depth=1, rkind=13
     )
   },
@@ -328,10 +325,9 @@ import frege.test.QuickCheckText;
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.prelude.PreludeBase", base="[]")}),
     @Meta.Tau(kind=0, suba=22, subb=10), @Meta.Tau(kind=8, suba=2, subb=2),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.prelude.PreludeBase", base="RealWorld")}),
-    @Meta.Tau(kind=0, suba=13, subb=25),
+    @Meta.Tau(kind=0, suba=13, subb=25), @Meta.Tau(kind=0, suba=26, subb=12),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.compiler.types.Global", base="Global")}),
-    @Meta.Tau(kind=0, suba=26, subb=27), @Meta.Tau(kind=0, suba=16, subb=25), @Meta.Tau(kind=0, suba=9, subb=3),
-    @Meta.Tau(kind=0, suba=29, subb=30), @Meta.Tau(kind=0, suba=26, subb=31)
+    @Meta.Tau(kind=0, suba=9, subb=3), @Meta.Tau(kind=0, suba=17, subb=29), @Meta.Tau(kind=0, suba=15, subb=30)
   },
   rhos={
     @Meta.Rho(rhofun=false, rhotau=0), @Meta.Rho(rhofun=false, rhotau=1), @Meta.Rho(sigma=1, rhotau=0),
@@ -341,8 +337,8 @@ import frege.test.QuickCheckText;
     @Meta.Rho(rhofun=false, rhotau=11), @Meta.Rho(rhofun=false, rhotau=12), @Meta.Rho(rhofun=false, rhotau=19),
     @Meta.Rho(sigma=10, rhotau=14), @Meta.Rho(rhofun=false, rhotau=18), @Meta.Rho(rhofun=false, rhotau=10),
     @Meta.Rho(rhofun=false, rhotau=21), @Meta.Rho(sigma=13, rhotau=18), @Meta.Rho(sigma=12, rhotau=19),
-    @Meta.Rho(rhofun=false, rhotau=23), @Meta.Rho(sigma=15, rhotau=14), @Meta.Rho(rhofun=false, rhotau=28),
-    @Meta.Rho(rhofun=false, rhotau=32), @Meta.Rho(sigma=17, rhotau=24), @Meta.Rho(sigma=7, rhotau=24)
+    @Meta.Rho(rhofun=false, rhotau=23), @Meta.Rho(sigma=15, rhotau=14), @Meta.Rho(rhofun=false, rhotau=27),
+    @Meta.Rho(rhofun=false, rhotau=28), @Meta.Rho(rhofun=false, rhotau=31), @Meta.Rho(sigma=18, rhotau=25)
   },
   sigmas={
     @Meta.Sigma(rho=0), @Meta.Sigma(rho=1), @Meta.Sigma(rho=2), @Meta.Sigma(rho=3), @Meta.Sigma(rho=4),
@@ -350,7 +346,8 @@ import frege.test.QuickCheckText;
     @Meta.Sigma(bound={"a"}, kinds={2}, rho=12), @Meta.Sigma(rho=13),
     @Meta.Sigma(bound={"a", "s"}, kinds={2, 2}, rho=15), @Meta.Sigma(rho=16), @Meta.Sigma(rho=17),
     @Meta.Sigma(bound={"a", "s"}, kinds={2, 2}, rho=20), @Meta.Sigma(rho=21),
-    @Meta.Sigma(bound={"a", "s"}, kinds={2, 2}, rho=22), @Meta.Sigma(rho=23), @Meta.Sigma(rho=25), @Meta.Sigma(rho=26)
+    @Meta.Sigma(bound={"a", "s"}, kinds={2, 2}, rho=22), @Meta.Sigma(rho=23), @Meta.Sigma(rho=24),
+    @Meta.Sigma(bound={"s"}, kinds={2}, rho=26)
   },
   exprs={@Meta.Expr()}
 )
@@ -376,13 +373,13 @@ final public static class TDiagnosticSeverityLSP  {
 }
 final public static class TDiagnosticLSP  {
   final public static org.eclipse.lsp4j.Diagnostic fromDiagnostic(final Diagnostic.TDiagnostic arg$1) {
-    final String/*<Character>*/ message$17370 = arg$1.mem$message.call();
-    final String/*<Character>*/ source$17369 = arg$1.mem$source.call();
-    final short severity$17368 = (short)arg$1.mem$severity.call();
-    final Range.TRange range$17367 = arg$1.mem$range.call();
+    final String/*<Character>*/ message$17368 = arg$1.mem$message.call();
+    final String/*<Character>*/ source$17367 = arg$1.mem$source.call();
+    final short severity$17366 = (short)arg$1.mem$severity.call();
+    final Range.TRange range$17365 = arg$1.mem$range.call();
     return new org.eclipse.lsp4j.Diagnostic(
-          RangeLSP4J.TRangeLSP.fromRange(range$17367), message$17370,
-          TDiagnosticSeverityLSP.fromCompilerSeverity(severity$17368), source$17369
+          RangeLSP4J.TRangeLSP.fromRange(range$17365), message$17368,
+          TDiagnosticSeverityLSP.fromCompilerSeverity(severity$17366), source$17367
         );
   }
 }
@@ -400,104 +397,81 @@ final public static class TArrayList  {
             });
   }
   final public static <𝓐, 𝓢> Func.U<𝓢, java.util.ArrayList<𝓐>> fromFregeList(final Lazy<PreludeBase.TList<𝓐>> arg$1) {
-    return (Func.U<𝓢, java.util.ArrayList<𝓐>>)((final Lazy<𝓢> arg$17561) -> {
-              final java.util.ArrayList<𝓐> v2056$17541 = TArrayList.<𝓐, 𝓢>$new(PreludeBase.TUnit.Unit)
-              .apply(arg$17561).call();
-              final Func.U<𝓢, java.util.ArrayList<𝓐>> v2057$17542 = DiagnosticLSP.<𝓐, 𝓢>go(
-                    arg$1.call(), Thunk.<java.util.ArrayList<𝓐>>lazy(v2056$17541)
+    return (Func.U<𝓢, java.util.ArrayList<𝓐>>)((final Lazy<𝓢> arg$17494) -> {
+              final java.util.ArrayList<𝓐> v2056$17474 = TArrayList.<𝓐, 𝓢>$new(PreludeBase.TUnit.Unit)
+              .apply(arg$17494).call();
+              final Func.U<𝓢, java.util.ArrayList<𝓐>> v2057$17475 = DiagnosticLSP.<𝓐, 𝓢>go(
+                    arg$1.call(), Thunk.<java.util.ArrayList<𝓐>>lazy(v2056$17474)
                   );
               return Thunk.<java.util.ArrayList<𝓐>>nested(
-                        (Lazy<Lazy<java.util.ArrayList<𝓐>>>)(() -> v2057$17542.apply(
-                                  arg$17561
+                        (Lazy<Lazy<java.util.ArrayList<𝓐>>>)(() -> v2057$17475.apply(
+                                  arg$17494
                                 ))
                       );
             });
   }
 }
+final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWorld, Short>>shared(
+      (Lazy<Func.U<RealWorld, Short>>)(() -> {
+            return Prelude.<String/*<Character>*/>println(PreludeText.IShow_String.it, "hello DiagnosticLSP");
+          })
+    );
 final public static <𝓐, 𝓢> Func.U<𝓢, java.util.ArrayList<𝓐>> go(
   final PreludeBase.TList<𝓐> arg$1, final Lazy<java.util.ArrayList<𝓐>> arg$2
 ) {
-  final PreludeBase.TList.DCons<𝓐> $17564 = arg$1.asCons();
-  if ($17564 != null) {
-    final 𝓐 µ$$17386 = $17564.mem1.call();
-    return (Func.U<𝓢, java.util.ArrayList<𝓐>>)((final Lazy<𝓢> arg$17566) -> {
-              final boolean v4796$17473 = (boolean)TArrayList.<𝓐, 𝓢>add(arg$2.call(), µ$$17386)
-              .apply(arg$17566).call();
-              final Func.U<𝓢, java.util.ArrayList<𝓐>> v4797$17474 = Thunk.<Func.U<𝓢, java.util.ArrayList<𝓐>>>shared(
+  final PreludeBase.TList.DCons<𝓐> $17497 = arg$1.asCons();
+  if ($17497 != null) {
+    final 𝓐 µ$$17381 = $17497.mem1.call();
+    return (Func.U<𝓢, java.util.ArrayList<𝓐>>)((final Lazy<𝓢> arg$17499) -> {
+              final boolean v4796$17450 = (boolean)TArrayList.<𝓐, 𝓢>add(arg$2.call(), µ$$17381)
+              .apply(arg$17499).call();
+              final Func.U<𝓢, java.util.ArrayList<𝓐>> v4797$17451 = Thunk.<Func.U<𝓢, java.util.ArrayList<𝓐>>>shared(
                     (Lazy<Func.U<𝓢, java.util.ArrayList<𝓐>>>)(() -> DiagnosticLSP.<𝓐, 𝓢>go(
-                              $17564.mem2.call(), arg$2
+                              $17497.mem2.call(), arg$2
                             ))
                   ).call();
               return Thunk.<java.util.ArrayList<𝓐>>nested(
-                        (Lazy<Lazy<java.util.ArrayList<𝓐>>>)(() -> v4797$17474.apply(
-                                  arg$17566
+                        (Lazy<Lazy<java.util.ArrayList<𝓐>>>)(() -> v4797$17451.apply(
+                                  arg$17499
                                 ))
                       );
             });
   }
-  final PreludeBase.TList.DList<𝓐> $17569 = arg$1.asList();
-  assert $17569 != null;
+  final PreludeBase.TList.DList<𝓐> $17502 = arg$1.asList();
+  assert $17502 != null;
   return PreludeMonad.IMonad_ST.<𝓢, java.util.ArrayList<𝓐>>pure(arg$2);
 }
-final public static Func.U<RealWorld, java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>> getDiagnosticsLSP(
-  final Func.U<RealWorld, Global.TGlobal> arg$1
+final public static <𝓢> Func.U<𝓢, java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>> getDiagnosticsLSP(
+  final Lazy<Global.TGlobal> arg$1
 ) {
-  return (Func.U<RealWorld, java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>>)((final Lazy<RealWorld> arg$17570) -> {
-            final PreludeBase.TList<Diagnostic.TDiagnostic> v2056$17497 = Diagnostic.getDiagnostics(
-                  arg$1
-                ).apply(arg$17570).call();
-            final Func.U<RealWorld, java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>> v2057$17498 =
-            TArrayList.<org.eclipse.lsp4j.Diagnostic, RealWorld>fromFregeList(
-                  Thunk.<PreludeBase.TList<org.eclipse.lsp4j.Diagnostic>>shared(
-                        (Lazy<PreludeBase.TList<org.eclipse.lsp4j.Diagnostic>>)(() -> PreludeMonad.IFunctor_$lbrack$rbrack.<
-                              Diagnostic.TDiagnostic, org.eclipse.lsp4j.Diagnostic
-                            >fmap(
-                                  (Func.U<Diagnostic.TDiagnostic, org.eclipse.lsp4j.Diagnostic>)((
-                                    final Lazy<Diagnostic.TDiagnostic> η$17572
-                                  ) -> Thunk.<org.eclipse.lsp4j.Diagnostic>shared(
-                                            (Lazy<org.eclipse.lsp4j.Diagnostic>)(() -> TDiagnosticLSP.fromDiagnostic(
-                                                      η$17572.call()
-                                                    ))
-                                          )),
-                                  v2056$17497
-                                ))
-                      )
-                );
-            return Thunk.<java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>>nested(
-                      (Lazy<Lazy<java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>>>)(() -> v2057$17498
-                          .apply(arg$17570))
-                    );
-          });
-}
-final public static Func.U<RealWorld, java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>> compileAndGetDiagnosticsLSP(
-  final Lazy<String/*<Character>*/> arg$1
-) {
-  return (Func.U<RealWorld, java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>>)((final Lazy<RealWorld> arg$17574) -> {
-            final PreludeBase.TList<Diagnostic.TDiagnostic> v2056$17519 = Diagnostic.compileAndGetDiagnostics(
-                  arg$1
-                ).apply(arg$17574).call();
-            final Func.U<RealWorld, java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>> v2057$17520 =
-            TArrayList.<org.eclipse.lsp4j.Diagnostic, RealWorld>fromFregeList(
-                  Thunk.<PreludeBase.TList<org.eclipse.lsp4j.Diagnostic>>shared(
-                        (Lazy<PreludeBase.TList<org.eclipse.lsp4j.Diagnostic>>)(() -> PreludeMonad.IFunctor_$lbrack$rbrack.<
-                              Diagnostic.TDiagnostic, org.eclipse.lsp4j.Diagnostic
-                            >fmap(
-                                  (Func.U<Diagnostic.TDiagnostic, org.eclipse.lsp4j.Diagnostic>)((
-                                    final Lazy<Diagnostic.TDiagnostic> η$17576
-                                  ) -> Thunk.<org.eclipse.lsp4j.Diagnostic>shared(
-                                            (Lazy<org.eclipse.lsp4j.Diagnostic>)(() -> TDiagnosticLSP.fromDiagnostic(
-                                                      η$17576.call()
-                                                    ))
-                                          )),
-                                  v2056$17519
-                                ))
-                      )
-                );
-            return Thunk.<java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>>nested(
-                      (Lazy<Lazy<java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>>>)(() -> v2057$17520
-                          .apply(arg$17574))
-                    );
-          });
+  return TArrayList.<org.eclipse.lsp4j.Diagnostic, 𝓢>fromFregeList(
+            Thunk.<PreludeBase.TList<org.eclipse.lsp4j.Diagnostic>>shared(
+                  (Lazy<PreludeBase.TList<org.eclipse.lsp4j.Diagnostic>>)(() -> PreludeMonad.IFunctor_$lbrack$rbrack.<
+                        Diagnostic.TDiagnostic, org.eclipse.lsp4j.Diagnostic
+                      >fmap(
+                            (Func.U<Diagnostic.TDiagnostic, org.eclipse.lsp4j.Diagnostic>)((
+                              final Lazy<Diagnostic.TDiagnostic> η$17503
+                            ) -> Thunk.<org.eclipse.lsp4j.Diagnostic>shared(
+                                      (Lazy<org.eclipse.lsp4j.Diagnostic>)(() -> TDiagnosticLSP.fromDiagnostic(
+                                                η$17503.call()
+                                              ))
+                                    )),
+                            Diagnostic.getDiagnostics(arg$1)
+                          ))
+                )
+          );
 }
 
+  public static void main(final java.lang.String[] argv) {
+    try {
+      frege.run.RunTM.argv = argv;
+      
+        PreludeBase.TST.<Short>performUnsafe($main
+               .call()
+          ).call();
+      frege.runtime.Runtime.stdout.get().close();
+      frege.runtime.Runtime.stderr.get().close();
+
+    } finally { frege.run.Concurrent.shutDownIfExists(); }
+  }
 }

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.java
@@ -143,28 +143,28 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.fr",
-  time=1658516066690L, jmajor=11, jminor=-1,
+  time=1658602830795L, jmajor=11, jminor=-1,
   imps={
-    "ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", "frege.Prelude", "frege.prelude.PreludeArrays",
-    "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal", "frege.prelude.PreludeIO", "frege.prelude.PreludeList",
-    "frege.prelude.PreludeMonad", "frege.prelude.PreludeText", "ch.fhnw.thga.fregelanguageserver.lsp4j.RangeLSP4J",
-    "frege.java.util.Regex"
+    "ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", "frege.compiler.types.Global", "frege.Prelude",
+    "frege.prelude.PreludeArrays", "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal",
+    "frege.prelude.PreludeIO", "frege.prelude.PreludeList", "frege.prelude.PreludeMonad", "frege.prelude.PreludeText",
+    "ch.fhnw.thga.fregelanguageserver.lsp4j.RangeLSP4J", "frege.java.util.Regex", "frege.control.monad.State"
   },
   nmss={
-    "Diagnostic", "Prelude", "PreludeArrays", "PreludeBase", "PreludeDecimal", "PreludeIO", "PreludeList",
-    "PreludeMonad", "PreludeText", "RangeLSP4J", "Regexp"
+    "Diagnostic", "Global", "Prelude", "PreludeArrays", "PreludeBase", "PreludeDecimal", "PreludeIO",
+    "PreludeList", "PreludeMonad", "PreludeText", "RangeLSP4J", "Regexp", "State"
   },
   symas={}, symcs={}, symis={},
   symts={
     @Meta.SymT(
-      offset=273,
+      offset=365,
       name=@Meta.QName(
         kind=0, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="DiagnosticSeverityLSP"
       ),
       typ=0, kind=2, cons={}, lnks={},
       funs={
         @Meta.SymV(
-          offset=472,
+          offset=564,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="DiagnosticSeverityLSP",
             member="warning"
@@ -173,7 +173,7 @@ import frege.test.QuickCheckText;
           depth=0, rkind=9
         ),
         @Meta.SymV(
-          offset=680,
+          offset=772,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="DiagnosticSeverityLSP",
             member="hint"
@@ -182,7 +182,7 @@ import frege.test.QuickCheckText;
           rkind=9
         ),
         @Meta.SymV(
-          offset=368,
+          offset=460,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="DiagnosticSeverityLSP",
             member="error"
@@ -191,7 +191,7 @@ import frege.test.QuickCheckText;
           rkind=9
         ),
         @Meta.SymV(
-          offset=773,
+          offset=865,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="DiagnosticSeverityLSP",
             member="fromCompilerSeverity"
@@ -199,7 +199,7 @@ import frege.test.QuickCheckText;
           stri="s(s)", sig=2, depth=1, rkind=13
         ),
         @Meta.SymV(
-          offset=576,
+          offset=668,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="DiagnosticSeverityLSP",
             member="information"
@@ -211,12 +211,12 @@ import frege.test.QuickCheckText;
       pur=true, nativ="org.eclipse.lsp4j.DiagnosticSeverity"
     ),
     @Meta.SymT(
-      offset=1053,
+      offset=1145,
       name=@Meta.QName(kind=0, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="DiagnosticLSP"),
       typ=3, kind=2, cons={}, lnks={},
       funs={
         @Meta.SymV(
-          offset=1215,
+          offset=1307,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="DiagnosticLSP",
             member="fromDiagnostic"
@@ -224,7 +224,7 @@ import frege.test.QuickCheckText;
           stri="s(s(ssss))", sig=5, depth=1, rkind=13
         ),
         @Meta.SymV(
-          offset=1132,
+          offset=1224,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="DiagnosticLSP",
             member="new"
@@ -235,12 +235,12 @@ import frege.test.QuickCheckText;
       pur=true, nativ="org.eclipse.lsp4j.Diagnostic"
     ),
     @Meta.SymT(
-      offset=1496,
+      offset=1588,
       name=@Meta.QName(kind=0, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="ArrayList"),
       typ=9, kind=24, cons={}, lnks={},
       funs={
         @Meta.SymV(
-          offset=1610,
+          offset=1702,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="ArrayList",
             member="new"
@@ -248,7 +248,7 @@ import frege.test.QuickCheckText;
           stri="s(s)", sig=11, nativ="new", depth=1, rkind=9
         ),
         @Meta.SymV(
-          offset=1552,
+          offset=1644,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="ArrayList",
             member="add"
@@ -256,7 +256,7 @@ import frege.test.QuickCheckText;
           stri="s(ss)", sig=14, nativ="add", depth=2, rkind=9
         ),
         @Meta.SymV(
-          offset=1652,
+          offset=1744,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="ArrayList",
             member="fromFregeList"
@@ -269,11 +269,16 @@ import frege.test.QuickCheckText;
   },
   symvs={
     @Meta.SymV(
-      offset=1916,
+      offset=2008,
+      name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="getDiagnosticsLSP"),
+      stri="s(s)", sig=18, depth=1, rkind=13
+    ),
+    @Meta.SymV(
+      offset=2261,
       name=@Meta.QName(
         pack="ch.fhnw.thga.fregelanguageserver.diagnostic.DiagnosticLSP", base="compileAndGetDiagnosticsLSP"
       ),
-      stri="s(u)", sig=17, depth=1, rkind=13
+      stri="s(u)", sig=19, depth=1, rkind=13
     )
   },
   symls={},
@@ -323,8 +328,10 @@ import frege.test.QuickCheckText;
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.prelude.PreludeBase", base="[]")}),
     @Meta.Tau(kind=0, suba=22, subb=10), @Meta.Tau(kind=8, suba=2, subb=2),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.prelude.PreludeBase", base="RealWorld")}),
-    @Meta.Tau(kind=0, suba=13, subb=25), @Meta.Tau(kind=0, suba=16, subb=25), @Meta.Tau(kind=0, suba=9, subb=3),
-    @Meta.Tau(kind=0, suba=27, subb=28), @Meta.Tau(kind=0, suba=26, subb=29)
+    @Meta.Tau(kind=0, suba=13, subb=25),
+    @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.compiler.types.Global", base="Global")}),
+    @Meta.Tau(kind=0, suba=26, subb=27), @Meta.Tau(kind=0, suba=16, subb=25), @Meta.Tau(kind=0, suba=9, subb=3),
+    @Meta.Tau(kind=0, suba=29, subb=30), @Meta.Tau(kind=0, suba=26, subb=31)
   },
   rhos={
     @Meta.Rho(rhofun=false, rhotau=0), @Meta.Rho(rhofun=false, rhotau=1), @Meta.Rho(sigma=1, rhotau=0),
@@ -334,8 +341,8 @@ import frege.test.QuickCheckText;
     @Meta.Rho(rhofun=false, rhotau=11), @Meta.Rho(rhofun=false, rhotau=12), @Meta.Rho(rhofun=false, rhotau=19),
     @Meta.Rho(sigma=10, rhotau=14), @Meta.Rho(rhofun=false, rhotau=18), @Meta.Rho(rhofun=false, rhotau=10),
     @Meta.Rho(rhofun=false, rhotau=21), @Meta.Rho(sigma=13, rhotau=18), @Meta.Rho(sigma=12, rhotau=19),
-    @Meta.Rho(rhofun=false, rhotau=23), @Meta.Rho(sigma=15, rhotau=14), @Meta.Rho(rhofun=false, rhotau=30),
-    @Meta.Rho(sigma=7, rhotau=23)
+    @Meta.Rho(rhofun=false, rhotau=23), @Meta.Rho(sigma=15, rhotau=14), @Meta.Rho(rhofun=false, rhotau=28),
+    @Meta.Rho(rhofun=false, rhotau=32), @Meta.Rho(sigma=17, rhotau=24), @Meta.Rho(sigma=7, rhotau=24)
   },
   sigmas={
     @Meta.Sigma(rho=0), @Meta.Sigma(rho=1), @Meta.Sigma(rho=2), @Meta.Sigma(rho=3), @Meta.Sigma(rho=4),
@@ -343,7 +350,7 @@ import frege.test.QuickCheckText;
     @Meta.Sigma(bound={"a"}, kinds={2}, rho=12), @Meta.Sigma(rho=13),
     @Meta.Sigma(bound={"a", "s"}, kinds={2, 2}, rho=15), @Meta.Sigma(rho=16), @Meta.Sigma(rho=17),
     @Meta.Sigma(bound={"a", "s"}, kinds={2, 2}, rho=20), @Meta.Sigma(rho=21),
-    @Meta.Sigma(bound={"a", "s"}, kinds={2, 2}, rho=22), @Meta.Sigma(rho=24)
+    @Meta.Sigma(bound={"a", "s"}, kinds={2, 2}, rho=22), @Meta.Sigma(rho=23), @Meta.Sigma(rho=25), @Meta.Sigma(rho=26)
   },
   exprs={@Meta.Expr()}
 )
@@ -369,13 +376,13 @@ final public static class TDiagnosticSeverityLSP  {
 }
 final public static class TDiagnosticLSP  {
   final public static org.eclipse.lsp4j.Diagnostic fromDiagnostic(final Diagnostic.TDiagnostic arg$1) {
-    final String/*<Character>*/ message$17364 = arg$1.mem$message.call();
-    final String/*<Character>*/ source$17363 = arg$1.mem$source.call();
-    final short severity$17362 = (short)arg$1.mem$severity.call();
-    final Range.TRange range$17361 = arg$1.mem$range.call();
+    final String/*<Character>*/ message$17370 = arg$1.mem$message.call();
+    final String/*<Character>*/ source$17369 = arg$1.mem$source.call();
+    final short severity$17368 = (short)arg$1.mem$severity.call();
+    final Range.TRange range$17367 = arg$1.mem$range.call();
     return new org.eclipse.lsp4j.Diagnostic(
-          RangeLSP4J.TRangeLSP.fromRange(range$17361), message$17364,
-          TDiagnosticSeverityLSP.fromCompilerSeverity(severity$17362), source$17363
+          RangeLSP4J.TRangeLSP.fromRange(range$17367), message$17370,
+          TDiagnosticSeverityLSP.fromCompilerSeverity(severity$17368), source$17369
         );
   }
 }
@@ -393,15 +400,15 @@ final public static class TArrayList  {
             });
   }
   final public static <𝓐, 𝓢> Func.U<𝓢, java.util.ArrayList<𝓐>> fromFregeList(final Lazy<PreludeBase.TList<𝓐>> arg$1) {
-    return (Func.U<𝓢, java.util.ArrayList<𝓐>>)((final Lazy<𝓢> arg$17515) -> {
-              final java.util.ArrayList<𝓐> v2056$17495 = TArrayList.<𝓐, 𝓢>$new(PreludeBase.TUnit.Unit)
-              .apply(arg$17515).call();
-              final Func.U<𝓢, java.util.ArrayList<𝓐>> v2057$17496 = DiagnosticLSP.<𝓐, 𝓢>go(
-                    arg$1.call(), Thunk.<java.util.ArrayList<𝓐>>lazy(v2056$17495)
+    return (Func.U<𝓢, java.util.ArrayList<𝓐>>)((final Lazy<𝓢> arg$17561) -> {
+              final java.util.ArrayList<𝓐> v2056$17541 = TArrayList.<𝓐, 𝓢>$new(PreludeBase.TUnit.Unit)
+              .apply(arg$17561).call();
+              final Func.U<𝓢, java.util.ArrayList<𝓐>> v2057$17542 = DiagnosticLSP.<𝓐, 𝓢>go(
+                    arg$1.call(), Thunk.<java.util.ArrayList<𝓐>>lazy(v2056$17541)
                   );
               return Thunk.<java.util.ArrayList<𝓐>>nested(
-                        (Lazy<Lazy<java.util.ArrayList<𝓐>>>)(() -> v2057$17496.apply(
-                                  arg$17515
+                        (Lazy<Lazy<java.util.ArrayList<𝓐>>>)(() -> v2057$17542.apply(
+                                  arg$17561
                                 ))
                       );
             });
@@ -410,55 +417,85 @@ final public static class TArrayList  {
 final public static <𝓐, 𝓢> Func.U<𝓢, java.util.ArrayList<𝓐>> go(
   final PreludeBase.TList<𝓐> arg$1, final Lazy<java.util.ArrayList<𝓐>> arg$2
 ) {
-  final PreludeBase.TList.DCons<𝓐> $17518 = arg$1.asCons();
-  if ($17518 != null) {
-    final 𝓐 µ$$17377 = $17518.mem1.call();
-    return (Func.U<𝓢, java.util.ArrayList<𝓐>>)((final Lazy<𝓢> arg$17520) -> {
-              final boolean v4796$17449 = (boolean)TArrayList.<𝓐, 𝓢>add(arg$2.call(), µ$$17377)
-              .apply(arg$17520).call();
-              final Func.U<𝓢, java.util.ArrayList<𝓐>> v4797$17450 = Thunk.<Func.U<𝓢, java.util.ArrayList<𝓐>>>shared(
+  final PreludeBase.TList.DCons<𝓐> $17564 = arg$1.asCons();
+  if ($17564 != null) {
+    final 𝓐 µ$$17386 = $17564.mem1.call();
+    return (Func.U<𝓢, java.util.ArrayList<𝓐>>)((final Lazy<𝓢> arg$17566) -> {
+              final boolean v4796$17473 = (boolean)TArrayList.<𝓐, 𝓢>add(arg$2.call(), µ$$17386)
+              .apply(arg$17566).call();
+              final Func.U<𝓢, java.util.ArrayList<𝓐>> v4797$17474 = Thunk.<Func.U<𝓢, java.util.ArrayList<𝓐>>>shared(
                     (Lazy<Func.U<𝓢, java.util.ArrayList<𝓐>>>)(() -> DiagnosticLSP.<𝓐, 𝓢>go(
-                              $17518.mem2.call(), arg$2
+                              $17564.mem2.call(), arg$2
                             ))
                   ).call();
               return Thunk.<java.util.ArrayList<𝓐>>nested(
-                        (Lazy<Lazy<java.util.ArrayList<𝓐>>>)(() -> v4797$17450.apply(
-                                  arg$17520
+                        (Lazy<Lazy<java.util.ArrayList<𝓐>>>)(() -> v4797$17474.apply(
+                                  arg$17566
                                 ))
                       );
             });
   }
-  final PreludeBase.TList.DList<𝓐> $17523 = arg$1.asList();
-  assert $17523 != null;
+  final PreludeBase.TList.DList<𝓐> $17569 = arg$1.asList();
+  assert $17569 != null;
   return PreludeMonad.IMonad_ST.<𝓢, java.util.ArrayList<𝓐>>pure(arg$2);
 }
-final public static Func.U<RealWorld, java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>> compileAndGetDiagnosticsLSP(
-  final Lazy<String/*<Character>*/> arg$1
+final public static Func.U<RealWorld, java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>> getDiagnosticsLSP(
+  final Func.U<RealWorld, Global.TGlobal> arg$1
 ) {
-  return (Func.U<RealWorld, java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>>)((final Lazy<RealWorld> arg$17524) -> {
-            final PreludeBase.TList<Diagnostic.TDiagnostic> v2056$17473 = Diagnostic.compileAndGetDiagnostics(
+  return (Func.U<RealWorld, java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>>)((final Lazy<RealWorld> arg$17570) -> {
+            final PreludeBase.TList<Diagnostic.TDiagnostic> v2056$17497 = Diagnostic.getDiagnostics(
                   arg$1
-                ).apply(arg$17524).call();
-            final Func.U<RealWorld, java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>> v2057$17474 =
+                ).apply(arg$17570).call();
+            final Func.U<RealWorld, java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>> v2057$17498 =
             TArrayList.<org.eclipse.lsp4j.Diagnostic, RealWorld>fromFregeList(
                   Thunk.<PreludeBase.TList<org.eclipse.lsp4j.Diagnostic>>shared(
                         (Lazy<PreludeBase.TList<org.eclipse.lsp4j.Diagnostic>>)(() -> PreludeMonad.IFunctor_$lbrack$rbrack.<
                               Diagnostic.TDiagnostic, org.eclipse.lsp4j.Diagnostic
                             >fmap(
                                   (Func.U<Diagnostic.TDiagnostic, org.eclipse.lsp4j.Diagnostic>)((
-                                    final Lazy<Diagnostic.TDiagnostic> η$17526
+                                    final Lazy<Diagnostic.TDiagnostic> η$17572
                                   ) -> Thunk.<org.eclipse.lsp4j.Diagnostic>shared(
                                             (Lazy<org.eclipse.lsp4j.Diagnostic>)(() -> TDiagnosticLSP.fromDiagnostic(
-                                                      η$17526.call()
+                                                      η$17572.call()
                                                     ))
                                           )),
-                                  v2056$17473
+                                  v2056$17497
                                 ))
                       )
                 );
             return Thunk.<java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>>nested(
-                      (Lazy<Lazy<java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>>>)(() -> v2057$17474
-                          .apply(arg$17524))
+                      (Lazy<Lazy<java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>>>)(() -> v2057$17498
+                          .apply(arg$17570))
+                    );
+          });
+}
+final public static Func.U<RealWorld, java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>> compileAndGetDiagnosticsLSP(
+  final Lazy<String/*<Character>*/> arg$1
+) {
+  return (Func.U<RealWorld, java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>>)((final Lazy<RealWorld> arg$17574) -> {
+            final PreludeBase.TList<Diagnostic.TDiagnostic> v2056$17519 = Diagnostic.compileAndGetDiagnostics(
+                  arg$1
+                ).apply(arg$17574).call();
+            final Func.U<RealWorld, java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>> v2057$17520 =
+            TArrayList.<org.eclipse.lsp4j.Diagnostic, RealWorld>fromFregeList(
+                  Thunk.<PreludeBase.TList<org.eclipse.lsp4j.Diagnostic>>shared(
+                        (Lazy<PreludeBase.TList<org.eclipse.lsp4j.Diagnostic>>)(() -> PreludeMonad.IFunctor_$lbrack$rbrack.<
+                              Diagnostic.TDiagnostic, org.eclipse.lsp4j.Diagnostic
+                            >fmap(
+                                  (Func.U<Diagnostic.TDiagnostic, org.eclipse.lsp4j.Diagnostic>)((
+                                    final Lazy<Diagnostic.TDiagnostic> η$17576
+                                  ) -> Thunk.<org.eclipse.lsp4j.Diagnostic>shared(
+                                            (Lazy<org.eclipse.lsp4j.Diagnostic>)(() -> TDiagnosticLSP.fromDiagnostic(
+                                                      η$17576.call()
+                                                    ))
+                                          )),
+                                  v2056$17519
+                                ))
+                      )
+                );
+            return Thunk.<java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>>nested(
+                      (Lazy<Lazy<java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>>>)(() -> v2057$17520
+                          .apply(arg$17574))
                     );
           });
 }

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticService.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticService.java
@@ -2,6 +2,7 @@ package ch.fhnw.thga.fregelanguageserver.diagnostic;
 
 import static frege.prelude.PreludeBase.TST.performUnsafe;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -10,20 +11,17 @@ import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.services.LanguageClient;
 
 import frege.compiler.types.Global.TGlobal;
-import frege.run8.Thunk;
-import frege.run8.Func.U;
-import frege.runtime.Phantom.RealWorld;
 
 public class DiagnosticService
 {
-    private static List<Diagnostic> getCompilerDiagnostics(U<RealWorld, TGlobal> global)
+    private static List<Diagnostic> getCompilerDiagnostics(TGlobal global)
     {
         return performUnsafe(DiagnosticLSP.getDiagnosticsLSP(global)).call();
     }
 
     public static void publishCompilerDiagnostics(
         LanguageClient client, 
-        U<RealWorld, TGlobal> global,
+        TGlobal global,
         String documentUri)
     {
 		CompletableFuture.runAsync(() -> 
@@ -32,4 +30,17 @@ public class DiagnosticService
                 documentUri, getCompilerDiagnostics(global)));
         });
 	}
+
+    public static void cleanCompilerDiagnostics
+        (
+            LanguageClient client,
+            String documentUri
+        )
+    {
+        CompletableFuture.runAsync(() -> 
+        {
+            client.publishDiagnostics(new PublishDiagnosticsParams(
+                documentUri, Collections.emptyList()));
+        });
+    }
 }

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticService.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticService.java
@@ -9,25 +9,27 @@ import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.services.LanguageClient;
 
+import frege.compiler.types.Global.TGlobal;
 import frege.run8.Thunk;
+import frege.run8.Func.U;
+import frege.runtime.Phantom.RealWorld;
 
 public class DiagnosticService
 {
-    private static List<Diagnostic> getCompilerDiagnostics(String fregeCode)
+    private static List<Diagnostic> getCompilerDiagnostics(U<RealWorld, TGlobal> global)
     {
-        return performUnsafe(
-            DiagnosticLSP.compileAndGetDiagnosticsLSP(Thunk.lazy(fregeCode))).call();
+        return performUnsafe(DiagnosticLSP.getDiagnosticsLSP(global)).call();
     }
 
     public static void publishCompilerDiagnostics(
         LanguageClient client, 
-        String fregeCode,
+        U<RealWorld, TGlobal> global,
         String documentUri)
     {
 		CompletableFuture.runAsync(() -> 
         {
             client.publishDiagnostics(new PublishDiagnosticsParams(
-                documentUri, getCompilerDiagnostics(fregeCode)));
+                documentUri, getCompilerDiagnostics(global)));
         });
 	}
 }

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/Hover.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/Hover.java
@@ -153,7 +153,7 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr",
-  time=1658602830271L, jmajor=11, jminor=-1,
+  time=1658948163634L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.compile.CompileExecutor",
     "ch.fhnw.thga.fregelanguageserver.compile.CompileGlobal", "frege.compiler.types.Global", "frege.data.List",
@@ -593,53 +593,53 @@ import frege.test.QuickCheckText;
       stri="s(u)", sig=35, depth=1, rkind=13
     ),
     @Meta.SymV(
-      offset=5232,
+      offset=5035,
       name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="shouldShowLocalConidDataConstructor"),
       stri="u", sig=36, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=4055,
+      offset=3782,
       name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="shouldShowLocalConidTypeSignature"),
       stri="u", sig=36, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=2912,
+      offset=2562,
       name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="shouldShowLocalVaridTypeSignature"),
       stri="u", sig=36, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=4645,
+      offset=4410,
       name=@Meta.QName(
         pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="shouldShowImportedConidTypeSignature"
       ),
       stri="u", sig=36, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=5874,
+      offset=5715,
       name=@Meta.QName(
         pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="shouldShowImportedConidDataConstructor"
       ),
       stri="u", sig=36, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=3474,
+      offset=3163,
       name=@Meta.QName(
         pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="shouldShowImportedVaridTypeSignature"
       ),
       stri="u", sig=36, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=6516, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="main"), stri="u",
+      offset=6395, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="main"), stri="u",
       sig=37, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=2522, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="getTypeOnHover"),
+      offset=2172, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="getTypeOnHover"),
       stri="s(u)", sig=39, depth=1, rkind=13
     ),
     @Meta.SymV(
-      offset=2332,
+      offset=2048,
       name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="getTypeSignatureOnHover"),
-      stri="s(su)", sig=41, depth=2, rkind=13
+      stri="s(uu)", sig=41, depth=2, rkind=13
     ),
     @Meta.SymV(
       offset=1140, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="getSymbolType"),
@@ -652,11 +652,6 @@ import frege.test.QuickCheckText;
     @Meta.SymV(
       offset=1272, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="findToken"), stri="s(u)",
       sig=46, depth=1, rkind=13
-    ),
-    @Meta.SymV(
-      offset=2048,
-      name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="compileAndGetTypeSignatureOnHover"),
-      stri="s(uu)", sig=47, depth=2, rkind=13
     )
   },
   symls={
@@ -715,10 +710,9 @@ import frege.test.QuickCheckText;
       kind=2, suba=0,
       tcon={@Meta.QName(kind=0, pack="ch.fhnw.thga.fregelanguageserver.types.Position", base="Position")}
     ),
-    @Meta.Tau(kind=0, suba=26, subb=8), @Meta.Tau(kind=0, suba=34, subb=23), @Meta.Tau(kind=0, suba=25, subb=8),
-    @Meta.Tau(kind=0, suba=34, subb=40),
+    @Meta.Tau(kind=0, suba=26, subb=8), @Meta.Tau(kind=0, suba=25, subb=8),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.compiler.types.Symbols", base="SymbolT")}),
-    @Meta.Tau(kind=0, suba=42, subb=23), @Meta.Tau(kind=0, suba=26, subb=3), @Meta.Tau(kind=0, suba=26, subb=43),
+    @Meta.Tau(kind=0, suba=40, subb=23), @Meta.Tau(kind=0, suba=26, subb=3), @Meta.Tau(kind=0, suba=26, subb=41),
     @Meta.Tau(kind=0, suba=26, subb=21)
   },
   rhos={
@@ -740,11 +734,10 @@ import frege.test.QuickCheckText;
     @Meta.Rho(sigma=0, rhotau=44), @Meta.Rho(rhofun=false, rhotau=21), @Meta.Rho(rhofun=false, rhotau=28),
     @Meta.Rho(sigma=34, rhotau=47), @Meta.Rho(rhofun=false, rhotau=31), @Meta.Rho(rhofun=false, rhotau=36),
     @Meta.Rho(rhofun=false, rhotau=37), @Meta.Rho(rhofun=false, rhotau=38), @Meta.Rho(sigma=38, rhotau=52),
-    @Meta.Rho(rhofun=false, rhotau=39), @Meta.Rho(rhofun=false, rhotau=41), @Meta.Rho(sigma=38, rhotau=55),
-    @Meta.Rho(sigma=40, rhotau=56), @Meta.Rho(rhofun=false, rhotau=43), @Meta.Rho(rhofun=false, rhotau=44),
-    @Meta.Rho(sigma=42, rhotau=59), @Meta.Rho(rhofun=false, rhotau=27), @Meta.Rho(rhofun=false, rhotau=45),
-    @Meta.Rho(sigma=44, rhotau=62), @Meta.Rho(rhofun=false, rhotau=46), @Meta.Rho(sigma=38, rhotau=64),
-    @Meta.Rho(sigma=3, rhotau=56)
+    @Meta.Rho(rhofun=false, rhotau=23), @Meta.Rho(rhofun=false, rhotau=39), @Meta.Rho(sigma=40, rhotau=55),
+    @Meta.Rho(sigma=38, rhotau=56), @Meta.Rho(rhofun=false, rhotau=41), @Meta.Rho(rhofun=false, rhotau=42),
+    @Meta.Rho(sigma=42, rhotau=59), @Meta.Rho(rhofun=false, rhotau=27), @Meta.Rho(rhofun=false, rhotau=43),
+    @Meta.Rho(sigma=44, rhotau=62), @Meta.Rho(rhofun=false, rhotau=44), @Meta.Rho(sigma=38, rhotau=64)
   },
   sigmas={
     @Meta.Sigma(rho=0), @Meta.Sigma(rho=2), @Meta.Sigma(rho=3), @Meta.Sigma(rho=1), @Meta.Sigma(rho=5),
@@ -756,7 +749,7 @@ import frege.test.QuickCheckText;
     @Meta.Sigma(rho=40), @Meta.Sigma(rho=41), @Meta.Sigma(rho=42), @Meta.Sigma(rho=43), @Meta.Sigma(rho=45),
     @Meta.Sigma(rho=46), @Meta.Sigma(rho=48), @Meta.Sigma(rho=49), @Meta.Sigma(rho=50), @Meta.Sigma(rho=51),
     @Meta.Sigma(rho=53), @Meta.Sigma(rho=54), @Meta.Sigma(rho=57), @Meta.Sigma(rho=58), @Meta.Sigma(rho=60),
-    @Meta.Sigma(rho=61), @Meta.Sigma(rho=63), @Meta.Sigma(rho=65), @Meta.Sigma(rho=66)
+    @Meta.Sigma(rho=61), @Meta.Sigma(rho=63), @Meta.Sigma(rho=65)
   },
   exprs={@Meta.Expr()}
 )
@@ -799,10 +792,10 @@ final public static class IShow_FregeCodeBlock implements PreludeText.CShow<Stri
               Thunk.<String/*<Character>*/>lazy(", "),
               PreludeList.<String/*<Character>*/, String/*<Character>*/>map(
                     (Func.U<String/*<Character>*/, String/*<Character>*/>)((
-                      final Lazy<String/*<Character>*/> η$20217
+                      final Lazy<String/*<Character>*/> η$20270
                     ) -> Thunk.<String/*<Character>*/>shared(
                               (Lazy<String/*<Character>*/>)(() -> IShow_FregeCodeBlock.show(
-                                        η$20217.call()
+                                        η$20270.call()
                                       ))
                             )),
                     arg$1
@@ -860,9 +853,9 @@ final public static class IShow_Hover implements PreludeText.CShow<THover> {
     return "[" + (PreludeText.joined(
               Thunk.<String/*<Character>*/>lazy(", "),
               PreludeList.<String/*<Character>*/, THover>map(
-                    (Func.U<THover, String/*<Character>*/>)((final Lazy<THover> η$20229) -> Thunk.<
+                    (Func.U<THover, String/*<Character>*/>)((final Lazy<THover> η$20282) -> Thunk.<
                           String/*<Character>*/
-                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_Hover.show(η$20229.call())))),
+                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_Hover.show(η$20282.call())))),
                     arg$1
                   )
             ).call() + ("]" + arg$2));
@@ -986,8 +979,8 @@ final public static class THover implements frege.runtime.Value, Lazy<THover> {
     return true;
   }
   final public static Range.TRange range(final THover arg$1) {
-    final Range.TRange a1$18117 = arg$1.mem$range.call();
-    return a1$18117;
+    final Range.TRange a1$18116 = arg$1.mem$range.call();
+    return a1$18116;
   }
   final public static THover chg$range(final THover arg$1, final Lazy<Func.U<Range.TRange, Range.TRange>> arg$2) {
     return THover.mk(
@@ -1006,8 +999,8 @@ final public static class THover implements frege.runtime.Value, Lazy<THover> {
             );
   }
   final public static String/*<Character>*/ content(final THover arg$1) {
-    final String/*<Character>*/ a2$18106 = arg$1.mem$content.call();
-    return a2$18106;
+    final String/*<Character>*/ a2$18105 = arg$1.mem$content.call();
+    return a2$18105;
   }
 }
 public static abstract class TFregeCodeBlock  {
@@ -1033,12 +1026,12 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.
 ) {
   return State.TStateT.<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.TQName>mk(
             (Func.U<Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>>)((
-              final Lazy<Global.TGlobal> arg$20250
+              final Lazy<Global.TGlobal> arg$20303
             ) -> {
-                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$19236 =
-                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20250, arg$20250)
+                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$19230 =
+                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20303, arg$20303)
                   .call();
-                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, PreludeBase.TEither<Short, QNames.TQName>> $20252 =
+                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, PreludeBase.TEither<Short, QNames.TQName>> $20305 =
                   State.IMonadTrans_StateT.<
                     Global.TGlobal, PreludeBase.TEither<Short, QNames.TQName>, PreludeBase.TMaybe<?>
                   >lift(
@@ -1049,7 +1042,7 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.
                                   >)Thunk.<PreludeBase.TMaybe<PreludeBase.TEither<Short, QNames.TQName>>>shared(
                                         (Lazy<PreludeBase.TMaybe<
                                           PreludeBase.TEither<Short, QNames.TQName>
-                                        >>)(() -> Global.TGlobal.resolved(v2895$19236.mem1.call(), arg$1))
+                                        >>)(() -> Global.TGlobal.resolved(v2895$19230.mem1.call(), arg$1))
                                       ).call())
                             )
                       );
@@ -1058,22 +1051,22 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.
                     Kind.U<
                       PreludeBase.TMaybe<?>, PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal>
                     >
-                  > v7734$19265 = $20252.mem$run;
+                  > v7734$19259 = $20305.mem$run;
                   final PreludeBase.TMaybe<
                     PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal>
-                  > $20254 = RunTM.<
+                  > $20307 = RunTM.<
                     Func.U<
                       Global.TGlobal,
                       PreludeBase.TMaybe<PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal>>
                     >
-                  >cast(v7734$19265).apply(v2895$19236.mem2).call();
+                  >cast(v7734$19259).apply(v2895$19230.mem2).call();
                   final PreludeBase.TMaybe.DJust<
                     PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal>
-                  > $20255 = $20254.asJust();
-                  if ($20255 != null) {
-                    final PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal> v2895$19297 =
-                    $20255.mem1.call();
-                    final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.TQName> $20259 =
+                  > $20308 = $20307.asJust();
+                  if ($20308 != null) {
+                    final PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal> v2895$19291 =
+                    $20308.mem1.call();
+                    final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.TQName> $20312 =
                     State.IMonadTrans_StateT.<Global.TGlobal, QNames.TQName, PreludeBase.TMaybe<?>>lift(
                           Maybe.IMonad_Maybe.it,
                           Thunk.<Kind.U<PreludeBase.TMaybe<?>, QNames.TQName>>shared(
@@ -1084,29 +1077,29 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.
                                                 PreludeBase.TMaybe<QNames.TQName>, Short, QNames.TQName
                                               >either(
                                                     (Func.U<Short, PreludeBase.TMaybe<QNames.TQName>>)((
-                                                      final Lazy<Short> η$20257
+                                                      final Lazy<Short> η$20310
                                                     ) -> Thunk.<PreludeBase.TMaybe<QNames.TQName>>shared(
                                                               (Lazy<PreludeBase.TMaybe<
                                                                 QNames.TQName
                                                               >>)(() -> PreludeBase.<
                                                                     Short, PreludeBase.TMaybe<QNames.TQName>
                                                                   >$const(
-                                                                        PreludeBase.TMaybe.DNothing.<QNames.TQName>mk(), η$20257
+                                                                        PreludeBase.TMaybe.DNothing.<QNames.TQName>mk(), η$20310
                                                                       ))
                                                             )),
                                                     (Func.U<QNames.TQName, PreludeBase.TMaybe<QNames.TQName>>)((
-                                                      final Lazy<QNames.TQName> η$20258
+                                                      final Lazy<QNames.TQName> η$20311
                                                     ) -> PreludeBase.TMaybe.DJust.<QNames.TQName>mk(
-                                                              η$20258
+                                                              η$20311
                                                             )),
-                                                    v2895$19297.mem1.call()
+                                                    v2895$19291.mem1.call()
                                                   ))
                                         ).call())
                               )
                         );
                     final Func.U<
                       Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>
-                    > v7739$19270 = $20259.mem$run;
+                    > v7739$19264 = $20312.mem$run;
                     return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>>shared(
                               (Lazy<Kind.U<
                                 PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>
@@ -1120,14 +1113,14 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.
                                                 Global.TGlobal,
                                                 PreludeBase.TMaybe<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>
                                               >
-                                            >cast(v7739$19270).apply(v2895$19297.mem2))
+                                            >cast(v7739$19264).apply(v2895$19291.mem2))
                                       ).call())
                             );
                   }
                   final PreludeBase.TMaybe.DNothing<
                     PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal>
-                  > $20261 = $20254.asNothing();
-                  assert $20261 != null;
+                  > $20314 = $20307.asNothing();
+                  assert $20314 != null;
                   return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>>lazy(
                             (Kind.U<
                               PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>
@@ -1142,17 +1135,17 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/
   return State.TStateT.<Global.TGlobal, PreludeBase.TMaybe<?>, String/*<Character>*/>mk(
             (Func.U<
               Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>>
-            >)((final Lazy<Global.TGlobal> arg$20262) -> {
-                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$19967 =
-                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20262, arg$20262)
+            >)((final Lazy<Global.TGlobal> arg$20315) -> {
+                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$20071 =
+                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20315, arg$20315)
                   .call();
-                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/*<Character>*/> $20264 =
+                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/*<Character>*/> $20317 =
                   State.IMonad_StateT.<Global.TGlobal, PreludeBase.TMaybe<?>, String/*<Character>*/>pure(
-                        Maybe.IMonad_Maybe.it, frege.ide.Utilities.<Global.TGlobal>label(v2895$19967.mem1, arg$1.call())
+                        Maybe.IMonad_Maybe.it, frege.ide.Utilities.<Global.TGlobal>label(v2895$20071.mem1, arg$1.call())
                       );
                   final Func.U<
                     Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>>
-                  > v7739$19940 = $20264.mem$run;
+                  > v7739$20044 = $20317.mem$run;
                   return Thunk.<
                         Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>>
                       >shared(
@@ -1168,7 +1161,7 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/
                                               Global.TGlobal,
                                               PreludeBase.TMaybe<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>>
                                             >
-                                          >cast(v7739$19940).apply(v2895$19967.mem2))
+                                          >cast(v7739$20044).apply(v2895$20071.mem2))
                                     ).call())
                           );
                 })
@@ -1177,9 +1170,9 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/
 final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.TToken> findToken(
   final Lazy<Position.TPosition> arg$1
 ) {
-  final class Let$20266  {
-    final Let$20266 let$20266 = this;
-    final public boolean isHoverOverToken$18131(final Tokens.TToken arg$2) {
+  final class Let$20319  {
+    final Let$20319 let$20319 = this;
+    final public boolean isHoverOverToken$18130(final Tokens.TToken arg$2) {
       return (Position.TPosition.line(arg$1.call()) == Tokens.TToken.line(arg$2)) && ((Position.TPosition.character(
                 arg$1.call()
               ) < (Tokens.TToken.col(arg$2) + Tokens.TToken.value(arg$2).length())) && (Position.TPosition.character(
@@ -1187,15 +1180,15 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.
               ) >= Tokens.TToken.col(arg$2)));
     }
   }
-  final Let$20266 let$20266 = new Let$20266();
+  final Let$20319 let$20319 = new Let$20319();
   return State.TStateT.<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.TToken>mk(
             (Func.U<Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>>>)((
-              final Lazy<Global.TGlobal> arg$20267
+              final Lazy<Global.TGlobal> arg$20320
             ) -> {
-                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$20103 =
-                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20267, arg$20267)
+                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$20207 =
+                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20320, arg$20320)
                   .call();
-                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.TToken> $20270 =
+                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.TToken> $20323 =
                   State.IMonadTrans_StateT.<Global.TGlobal, Tokens.TToken, PreludeBase.TMaybe<?>>lift(
                         Maybe.IMonad_Maybe.it,
                         Thunk.<Kind.U<PreludeBase.TMaybe<?>, Tokens.TToken>>shared(
@@ -1206,11 +1199,11 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.
                                               Tokens.TToken
                                             >find(
                                                   (Func.U<Tokens.TToken, Boolean>)((
-                                                    final Lazy<Tokens.TToken> η$20269
+                                                    final Lazy<Tokens.TToken> η$20322
                                                   ) -> Thunk.<Boolean>shared(
-                                                            (Lazy<Boolean>)(() -> let$20266
-                                                                .isHoverOverToken$18131(
-                                                                      η$20269.call()
+                                                            (Lazy<Boolean>)(() -> let$20319
+                                                                .isHoverOverToken$18130(
+                                                                      η$20322.call()
                                                                     ))
                                                           )),
                                                   Thunk.<PreludeBase.TList<Tokens.TToken>>shared(
@@ -1219,7 +1212,7 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.
                                                         >>)(() -> Tokens.IArrayElement_Token.listFromArray(
                                                                   Global.TSubSt.toks(
                                                                         Global.TGlobal.sub(
-                                                                              v2895$20103.mem1
+                                                                              v2895$20207.mem1
                                                                               .call()
                                                                             )
                                                                       )
@@ -1231,7 +1224,7 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.
                       );
                   final Func.U<
                     Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>>
-                  > v7739$20076 = $20270.mem$run;
+                  > v7739$20180 = $20323.mem$run;
                   return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>>>shared(
                             (Lazy<Kind.U<
                               PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>
@@ -1245,7 +1238,7 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.
                                               Global.TGlobal,
                                               PreludeBase.TMaybe<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>>
                                             >
-                                          >cast(v7739$20076).apply(v2895$20103.mem2))
+                                          >cast(v7739$20180).apply(v2895$20207.mem2))
                                     ).call())
                           );
                 })
@@ -1258,11 +1251,11 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols
             (Func.U<
               Global.TGlobal,
               Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>>
-            >)((final Lazy<Global.TGlobal> arg$20272) -> {
-                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$20035 =
-                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20272, arg$20272)
+            >)((final Lazy<Global.TGlobal> arg$20325) -> {
+                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$20139 =
+                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20325, arg$20325)
                   .call();
-                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols.TSymbolT<Global.TGlobal>> $20274 =
+                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols.TSymbolT<Global.TGlobal>> $20327 =
                   State.IMonadTrans_StateT.<Global.TGlobal, Symbols.TSymbolT<Global.TGlobal>, PreludeBase.TMaybe<?>>lift(
                         Maybe.IMonad_Maybe.it,
                         Thunk.<Kind.U<PreludeBase.TMaybe<?>, Symbols.TSymbolT<Global.TGlobal>>>shared(
@@ -1271,14 +1264,14 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols
                                   >)Thunk.<PreludeBase.TMaybe<Symbols.TSymbolT<Global.TGlobal>>>nested(
                                         (Lazy<Lazy<PreludeBase.TMaybe<
                                           Symbols.TSymbolT<Global.TGlobal>
-                                        >>>)(() -> Global.TGlobal.find(v2895$20035.mem1.call(), arg$1.call()))
+                                        >>>)(() -> Global.TGlobal.find(v2895$20139.mem1.call(), arg$1.call()))
                                       ).call())
                             )
                       );
                   final Func.U<
                     Global.TGlobal,
                     Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>>
-                  > v7739$20008 = $20274.mem$run;
+                  > v7739$20112 = $20327.mem$run;
                   return Thunk.<
                         Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>>
                       >shared(
@@ -1298,7 +1291,7 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols
                                                 PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>
                                               >
                                             >
-                                          >cast(v7739$20008).apply(v2895$20035.mem2))
+                                          >cast(v7739$20112).apply(v2895$20139.mem2))
                                     ).call())
                           );
                 })
@@ -1309,88 +1302,88 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover>
 ) {
   return State.TStateT.<Global.TGlobal, PreludeBase.TMaybe<?>, THover>mk(
             (Func.U<Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>>)((
-              final Lazy<Global.TGlobal> arg$20276
+              final Lazy<Global.TGlobal> arg$20329
             ) -> {
-                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$19694 =
-                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20276, arg$20276)
+                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$19820 =
+                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20329, arg$20329)
                   .call();
-                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.TToken> $20278 =
+                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.TToken> $20331 =
                   Hover.findToken(arg$1);
                   final Func.U<
                     Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>>
-                  > v7734$19723 = $20278.mem$run;
-                  final PreludeBase.TMaybe<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>> $20280 =
+                  > v7734$19849 = $20331.mem$run;
+                  final PreludeBase.TMaybe<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>> $20333 =
                   RunTM.<Func.U<Global.TGlobal, PreludeBase.TMaybe<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>>>>cast(
-                        v7734$19723
-                      ).apply(v2895$19694.mem2).call();
-                  final PreludeBase.TMaybe.DJust<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>> $20281 =
-                  $20280.asJust();
-                  if ($20281 != null) {
-                    final PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal> v2895$19755 =
-                    $20281.mem1.call();
-                    final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.TQName> $20283 =
-                    Hover.tokenToQName(v2895$19755.mem1);
+                        v7734$19849
+                      ).apply(v2895$19820.mem2).call();
+                  final PreludeBase.TMaybe.DJust<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>> $20334 =
+                  $20333.asJust();
+                  if ($20334 != null) {
+                    final PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal> v2895$19881 =
+                    $20334.mem1.call();
+                    final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.TQName> $20336 =
+                    Hover.tokenToQName(v2895$19881.mem1);
                     final Func.U<
                       Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>
-                    > v7734$19767 = $20283.mem$run;
-                    final PreludeBase.TMaybe<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>> $20285 =
+                    > v7734$19893 = $20336.mem$run;
+                    final PreludeBase.TMaybe<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>> $20338 =
                     RunTM.<Func.U<Global.TGlobal, PreludeBase.TMaybe<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>>>cast(
-                          v7734$19767
-                        ).apply(v2895$19755.mem2).call();
-                    final PreludeBase.TMaybe.DJust<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>> $20286 =
-                    $20285.asJust();
-                    if ($20286 != null) {
-                      final PreludeBase.TTuple2<QNames.TQName, Global.TGlobal> v2895$19799 =
-                      $20286.mem1.call();
-                      final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols.TSymbolT<Global.TGlobal>> $20288 =
-                      Hover.findSymbol(v2895$19799.mem1);
+                          v7734$19893
+                        ).apply(v2895$19881.mem2).call();
+                    final PreludeBase.TMaybe.DJust<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>> $20339 =
+                    $20338.asJust();
+                    if ($20339 != null) {
+                      final PreludeBase.TTuple2<QNames.TQName, Global.TGlobal> v2895$19925 =
+                      $20339.mem1.call();
+                      final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols.TSymbolT<Global.TGlobal>> $20341 =
+                      Hover.findSymbol(v2895$19925.mem1);
                       final Func.U<
                         Global.TGlobal,
                         Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>>
-                      > v7734$19811 = $20288.mem$run;
-                      final PreludeBase.TMaybe<PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>> $20290 =
+                      > v7734$19937 = $20341.mem$run;
+                      final PreludeBase.TMaybe<PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>> $20343 =
                       RunTM.<
                         Func.U<
                           Global.TGlobal,
                           PreludeBase.TMaybe<PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>>
                         >
-                      >cast(v7734$19811).apply(v2895$19799.mem2).call();
+                      >cast(v7734$19937).apply(v2895$19925.mem2).call();
                       final PreludeBase.TMaybe.DJust<
                         PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>
-                      > $20291 = $20290.asJust();
-                      if ($20291 != null) {
-                        final PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal> v2895$19843 =
-                        $20291.mem1.call();
-                        final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/*<Character>*/> $20293 =
-                        Hover.getSymbolType(v2895$19843.mem1);
+                      > $20344 = $20343.asJust();
+                      if ($20344 != null) {
+                        final PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal> v2895$19969 =
+                        $20344.mem1.call();
+                        final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/*<Character>*/> $20346 =
+                        Hover.getSymbolType(v2895$19969.mem1);
                         final Func.U<
                           Global.TGlobal,
                           Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>>
-                        > v7734$19855 = $20293.mem$run;
-                        final PreludeBase.TMaybe<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>> $20295 =
+                        > v7734$19981 = $20346.mem$run;
+                        final PreludeBase.TMaybe<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>> $20348 =
                         RunTM.<
                           Func.U<Global.TGlobal, PreludeBase.TMaybe<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>>>
-                        >cast(v7734$19855).apply(v2895$19843.mem2).call();
-                        final PreludeBase.TMaybe.DJust<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>> $20296 =
-                        $20295.asJust();
-                        if ($20296 != null) {
-                          final PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal> v2895$19887 =
-                          $20296.mem1.call();
-                          final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover> $20298 =
+                        >cast(v7734$19981).apply(v2895$19969.mem2).call();
+                        final PreludeBase.TMaybe.DJust<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>> $20349 =
+                        $20348.asJust();
+                        if ($20349 != null) {
+                          final PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal> v2895$20013 =
+                          $20349.mem1.call();
+                          final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover> $20351 =
                           State.IMonad_StateT.<Global.TGlobal, PreludeBase.TMaybe<?>, THover>pure(
                                 Maybe.IMonad_Maybe.it,
                                 THover.mk(
                                       Thunk.<Range.TRange>shared(
                                             (Lazy<Range.TRange>)(() -> Range.tokenToRange(
-                                                      v2895$19755.mem1.call()
+                                                      v2895$19881.mem1.call()
                                                     ))
                                           ),
-                                      v2895$19887.mem1
+                                      v2895$20013.mem1
                                     )
                               );
                           final Func.U<
                             Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>
-                          > v7739$19860 = $20298.mem$run;
+                          > v7739$19986 = $20351.mem$run;
                           return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>>shared(
                                     (Lazy<Kind.U<
                                       PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>
@@ -1404,13 +1397,13 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover>
                                                       Global.TGlobal,
                                                       PreludeBase.TMaybe<PreludeBase.TTuple2<THover, Global.TGlobal>>
                                                     >
-                                                  >cast(v7739$19860).apply(v2895$19887.mem2))
+                                                  >cast(v7739$19986).apply(v2895$20013.mem2))
                                             ).call())
                                   );
                         }
-                        final PreludeBase.TMaybe.DNothing<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>> $20300 =
-                        $20295.asNothing();
-                        assert $20300 != null;
+                        final PreludeBase.TMaybe.DNothing<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>> $20353 =
+                        $20348.asNothing();
+                        assert $20353 != null;
                         return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>>lazy(
                                   (Kind.U<
                                     PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>
@@ -1419,26 +1412,26 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover>
                       }
                       final PreludeBase.TMaybe.DNothing<
                         PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>
-                      > $20301 = $20290.asNothing();
-                      assert $20301 != null;
+                      > $20354 = $20343.asNothing();
+                      assert $20354 != null;
                       return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>>lazy(
                                 (Kind.U<
                                   PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>
                                 >)PreludeBase.TMaybe.DNothing.<PreludeBase.TTuple2<THover, Global.TGlobal>>mk()
                               );
                     }
-                    final PreludeBase.TMaybe.DNothing<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>> $20302 =
-                    $20285.asNothing();
-                    assert $20302 != null;
+                    final PreludeBase.TMaybe.DNothing<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>> $20355 =
+                    $20338.asNothing();
+                    assert $20355 != null;
                     return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>>lazy(
                               (Kind.U<
                                 PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>
                               >)PreludeBase.TMaybe.DNothing.<PreludeBase.TTuple2<THover, Global.TGlobal>>mk()
                             );
                   }
-                  final PreludeBase.TMaybe.DNothing<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>> $20303 =
-                  $20280.asNothing();
-                  assert $20303 != null;
+                  final PreludeBase.TMaybe.DNothing<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>> $20356 =
+                  $20333.asNothing();
+                  assert $20356 != null;
                   return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>>lazy(
                             (Kind.U<
                               PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>
@@ -1447,40 +1440,20 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover>
                 })
           );
 }
-final public static Func.U<RealWorld, PreludeBase.TMaybe<THover>> getTypeSignatureOnHover(
-  final Func.U<RealWorld, Global.TGlobal> arg$1, final Lazy<Position.TPosition> arg$2
+final public static PreludeBase.TMaybe<THover> getTypeSignatureOnHover(
+  final Lazy<Position.TPosition> arg$1, final Lazy<Global.TGlobal> arg$2
 ) {
-  return (Func.U<RealWorld, PreludeBase.TMaybe<THover>>)((final Lazy<RealWorld> arg$20304) -> {
-            final Global.TGlobal v2056$19908 = arg$1.apply(arg$20304).call();
-            final Func.U<RealWorld, PreludeBase.TMaybe<THover>> v2057$19909 = PreludeMonad.IMonad_ST.<
-              RealWorld, PreludeBase.TMaybe<THover>
-            >pure(
-                  Thunk.<PreludeBase.TMaybe<THover>>shared(
-                        (Lazy<PreludeBase.TMaybe<THover>>)(() -> PreludeBase.TMaybe.<THover>coerce(
-                                  Thunk.<Kind.U<PreludeBase.TMaybe<?>, THover>>shared(
-                                        (Lazy<Kind.U<PreludeBase.TMaybe<?>, THover>>)(() -> State.<
-                                              THover, PreludeBase.TMaybe<?>, Global.TGlobal
-                                            >evalStateT(
-                                                  Maybe.IMonad_Maybe.it,
-                                                  Thunk.<State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover>>shared(
-                                                        (Lazy<State.TStateT<
-                                                          Global.TGlobal, PreludeBase.TMaybe<?>, THover
-                                                        >>)(() -> Hover.getTypeOnHover(
-                                                                  arg$2
-                                                                ))
-                                                      ),
-                                                  v2056$19908
-                                                ))
-                                      ).call()
+  return PreludeBase.TMaybe.<THover>coerce(
+            State.<THover, PreludeBase.TMaybe<?>, Global.TGlobal>evalStateT(
+                  Maybe.IMonad_Maybe.it,
+                  Thunk.<State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover>>shared(
+                        (Lazy<State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover>>)(() -> Hover.getTypeOnHover(
+                                  arg$1
                                 ))
-                      )
-                );
-            return Thunk.<PreludeBase.TMaybe<THover>>nested(
-                      (Lazy<Lazy<PreludeBase.TMaybe<THover>>>)(() -> v2057$19909.apply(
-                                arg$20304
-                              ))
-                    );
-          });
+                      ),
+                  arg$2
+                )
+          );
 }
 final public static Lazy<QuickCheckGen.TGen<
   QuickCheckProperty.TRose<QuickCheckProperty.TResult>
@@ -1495,21 +1468,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20307) -> {
-                                            final PreludeBase.TMaybe<THover> v2056$19404 =
-                                            Hover.getTypeSignatureOnHover(
-                                                  CompileExecutor.compile(
-                                                        Thunk.<String/*<Character>*/>shared(
-                                                              (Lazy<String/*
-                                                                <Character>
-                                                              */>)(() -> "module HoverTest where\n\n" + "simplyString = \"Hello\"")
-                                                            ),
-                                                        CompileGlobal.standardCompileGlobal
-                                                        .call()
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20357) -> {
+                                            final Global.TGlobal v2056$19442 = CompileGlobal.standardCompileGlobal
+                                            .call().apply(arg$20357).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$19461 =
+                                            CompileExecutor.compile(
+                                                  Thunk.<String/*<Character>*/>shared(
+                                                        (Lazy<String/*
+                                                          <Character>
+                                                        */>)(() -> "module HoverTest where\n\n" + "simplyString = \"Hello\"")
                                                       ),
-                                                  Position.TPosition.mk(Thunk.<Integer>lazy(3), Thunk.<Integer>lazy(3))
-                                                ).apply(arg$20307).call();
-                                            final Func.U<RealWorld, Boolean> v2057$19405 =
+                                                  v2056$19442
+                                                );
+                                            final Global.TGlobal v2056$19464 = v2053$19461
+                                            .apply(arg$20357).call();
+                                            final Func.U<RealWorld, Boolean> v2057$19465 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Maybe.IEq_Maybe.<
@@ -1551,13 +1524,18 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                                   )
                                                                             )
                                                                       ),
-                                                                  v2056$19404
+                                                                  Hover.getTypeSignatureOnHover(
+                                                                        Position.TPosition.mk(
+                                                                              Thunk.<Integer>lazy(3), Thunk.<Integer>lazy(3)
+                                                                            ),
+                                                                        v2056$19464
+                                                                      )
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19405
-                                                          .apply(arg$20307))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19465
+                                                          .apply(arg$20357))
                                                     );
                                           })
                                     ))
@@ -1578,21 +1556,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20310) -> {
-                                            final PreludeBase.TMaybe<THover> v2056$19368 =
-                                            Hover.getTypeSignatureOnHover(
-                                                  CompileExecutor.compile(
-                                                        Thunk.<String/*<Character>*/>shared(
-                                                              (Lazy<String/*
-                                                                <Character>
-                                                              */>)(() -> "module HoverTest where\n\n" + "data MyMaybe a = MyNothing | MyJust a\n")
-                                                            ),
-                                                        CompileGlobal.standardCompileGlobal
-                                                        .call()
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20362) -> {
+                                            final Global.TGlobal v2056$19384 = CompileGlobal.standardCompileGlobal
+                                            .call().apply(arg$20362).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$19403 =
+                                            CompileExecutor.compile(
+                                                  Thunk.<String/*<Character>*/>shared(
+                                                        (Lazy<String/*
+                                                          <Character>
+                                                        */>)(() -> "module HoverTest where\n\n" + "data MyMaybe a = MyNothing | MyJust a\n")
                                                       ),
-                                                  Position.TPosition.mk(Thunk.<Integer>lazy(3), Thunk.<Integer>lazy(7))
-                                                ).apply(arg$20310).call();
-                                            final Func.U<RealWorld, Boolean> v2057$19369 =
+                                                  v2056$19384
+                                                );
+                                            final Global.TGlobal v2056$19406 = v2053$19403
+                                            .apply(arg$20362).call();
+                                            final Func.U<RealWorld, Boolean> v2057$19407 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Maybe.IEq_Maybe.<
@@ -1634,13 +1612,18 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                                   )
                                                                             )
                                                                       ),
-                                                                  v2056$19368
+                                                                  Hover.getTypeSignatureOnHover(
+                                                                        Position.TPosition.mk(
+                                                                              Thunk.<Integer>lazy(3), Thunk.<Integer>lazy(7)
+                                                                            ),
+                                                                        v2056$19406
+                                                                      )
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19369
-                                                          .apply(arg$20310))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19407
+                                                          .apply(arg$20362))
                                                     );
                                           })
                                     ))
@@ -1661,21 +1644,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20313) -> {
-                                            final PreludeBase.TMaybe<THover> v2056$19332 =
-                                            Hover.getTypeSignatureOnHover(
-                                                  CompileExecutor.compile(
-                                                        Thunk.<String/*<Character>*/>shared(
-                                                              (Lazy<String/*
-                                                                <Character>
-                                                              */>)(() -> "module HoverTest where\n\n" + ("data MyMaybe a = MyNothing | MyJust a\n" + "res = MyJust 42"))
-                                                            ),
-                                                        CompileGlobal.standardCompileGlobal
-                                                        .call()
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20367) -> {
+                                            final Global.TGlobal v2056$19326 = CompileGlobal.standardCompileGlobal
+                                            .call().apply(arg$20367).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$19345 =
+                                            CompileExecutor.compile(
+                                                  Thunk.<String/*<Character>*/>shared(
+                                                        (Lazy<String/*
+                                                          <Character>
+                                                        */>)(() -> "module HoverTest where\n\n" + ("data MyMaybe a = MyNothing | MyJust a\n" + "res = MyJust 42"))
                                                       ),
-                                                  Position.TPosition.mk(Thunk.<Integer>lazy(4), Thunk.<Integer>lazy(8))
-                                                ).apply(arg$20313).call();
-                                            final Func.U<RealWorld, Boolean> v2057$19333 =
+                                                  v2056$19326
+                                                );
+                                            final Global.TGlobal v2056$19348 = v2053$19345
+                                            .apply(arg$20367).call();
+                                            final Func.U<RealWorld, Boolean> v2057$19349 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Maybe.IEq_Maybe.<
@@ -1717,13 +1700,18 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                                   )
                                                                             )
                                                                       ),
-                                                                  v2056$19332
+                                                                  Hover.getTypeSignatureOnHover(
+                                                                        Position.TPosition.mk(
+                                                                              Thunk.<Integer>lazy(4), Thunk.<Integer>lazy(8)
+                                                                            ),
+                                                                        v2056$19348
+                                                                      )
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19333
-                                                          .apply(arg$20313))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19349
+                                                          .apply(arg$20367))
                                                     );
                                           })
                                     ))
@@ -1746,21 +1734,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20316) -> {
-                                            final PreludeBase.TMaybe<THover> v2056$19512 =
-                                            Hover.getTypeSignatureOnHover(
-                                                  CompileExecutor.compile(
-                                                        Thunk.<String/*<Character>*/>shared(
-                                                              (Lazy<String/*
-                                                                <Character>
-                                                              */>)(() -> "module HoverTest where\n\n" + "main = println \"Hello\"")
-                                                            ),
-                                                        CompileGlobal.standardCompileGlobal
-                                                        .call()
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20372) -> {
+                                            final Global.TGlobal v2056$19616 = CompileGlobal.standardCompileGlobal
+                                            .call().apply(arg$20372).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$19635 =
+                                            CompileExecutor.compile(
+                                                  Thunk.<String/*<Character>*/>shared(
+                                                        (Lazy<String/*
+                                                          <Character>
+                                                        */>)(() -> "module HoverTest where\n\n" + "main = println \"Hello\"")
                                                       ),
-                                                  Position.TPosition.mk(Thunk.<Integer>lazy(3), Thunk.<Integer>lazy(9))
-                                                ).apply(arg$20316).call();
-                                            final Func.U<RealWorld, Boolean> v2057$19513 =
+                                                  v2056$19616
+                                                );
+                                            final Global.TGlobal v2056$19638 = v2053$19635
+                                            .apply(arg$20372).call();
+                                            final Func.U<RealWorld, Boolean> v2057$19639 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Maybe.IEq_Maybe.<
@@ -1802,13 +1790,18 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                                   )
                                                                             )
                                                                       ),
-                                                                  v2056$19512
+                                                                  Hover.getTypeSignatureOnHover(
+                                                                        Position.TPosition.mk(
+                                                                              Thunk.<Integer>lazy(3), Thunk.<Integer>lazy(9)
+                                                                            ),
+                                                                        v2056$19638
+                                                                      )
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19513
-                                                          .apply(arg$20316))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19639
+                                                          .apply(arg$20372))
                                                     );
                                           })
                                     ))
@@ -1831,21 +1824,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20319) -> {
-                                            final PreludeBase.TMaybe<THover> v2056$19440 =
-                                            Hover.getTypeSignatureOnHover(
-                                                  CompileExecutor.compile(
-                                                        Thunk.<String/*<Character>*/>shared(
-                                                              (Lazy<String/*
-                                                                <Character>
-                                                              */>)(() -> "module HoverTest where\n\n" + "import frege.data.Maybe(Maybe)")
-                                                            ),
-                                                        CompileGlobal.standardCompileGlobal
-                                                        .call()
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20377) -> {
+                                            final Global.TGlobal v2056$19500 = CompileGlobal.standardCompileGlobal
+                                            .call().apply(arg$20377).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$19519 =
+                                            CompileExecutor.compile(
+                                                  Thunk.<String/*<Character>*/>shared(
+                                                        (Lazy<String/*
+                                                          <Character>
+                                                        */>)(() -> "module HoverTest where\n\n" + "import frege.data.Maybe(Maybe)")
                                                       ),
-                                                  Position.TPosition.mk(Thunk.<Integer>lazy(3), Thunk.<Integer>lazy(27))
-                                                ).apply(arg$20319).call();
-                                            final Func.U<RealWorld, Boolean> v2057$19441 =
+                                                  v2056$19500
+                                                );
+                                            final Global.TGlobal v2056$19522 = v2053$19519
+                                            .apply(arg$20377).call();
+                                            final Func.U<RealWorld, Boolean> v2057$19523 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Maybe.IEq_Maybe.<
@@ -1887,13 +1880,18 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                                   )
                                                                             )
                                                                       ),
-                                                                  v2056$19440
+                                                                  Hover.getTypeSignatureOnHover(
+                                                                        Position.TPosition.mk(
+                                                                              Thunk.<Integer>lazy(3), Thunk.<Integer>lazy(27)
+                                                                            ),
+                                                                        v2056$19522
+                                                                      )
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19441
-                                                          .apply(arg$20319))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19523
+                                                          .apply(arg$20377))
                                                     );
                                           })
                                     ))
@@ -1916,21 +1914,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20322) -> {
-                                            final PreludeBase.TMaybe<THover> v2056$19476 =
-                                            Hover.getTypeSignatureOnHover(
-                                                  CompileExecutor.compile(
-                                                        Thunk.<String/*<Character>*/>shared(
-                                                              (Lazy<String/*
-                                                                <Character>
-                                                              */>)(() -> "module HoverTest where\n\n" + ("import frege.data.Maybe(Maybe, Just)\n" + "res = Just 42"))
-                                                            ),
-                                                        CompileGlobal.standardCompileGlobal
-                                                        .call()
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20382) -> {
+                                            final Global.TGlobal v2056$19558 = CompileGlobal.standardCompileGlobal
+                                            .call().apply(arg$20382).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$19577 =
+                                            CompileExecutor.compile(
+                                                  Thunk.<String/*<Character>*/>shared(
+                                                        (Lazy<String/*
+                                                          <Character>
+                                                        */>)(() -> "module HoverTest where\n\n" + ("import frege.data.Maybe(Maybe, Just)\n" + "res = Just 42"))
                                                       ),
-                                                  Position.TPosition.mk(Thunk.<Integer>lazy(4), Thunk.<Integer>lazy(10))
-                                                ).apply(arg$20322).call();
-                                            final Func.U<RealWorld, Boolean> v2057$19477 =
+                                                  v2056$19558
+                                                );
+                                            final Global.TGlobal v2056$19580 = v2053$19577
+                                            .apply(arg$20382).call();
+                                            final Func.U<RealWorld, Boolean> v2057$19581 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Maybe.IEq_Maybe.<
@@ -1972,13 +1970,18 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                                   )
                                                                             )
                                                                       ),
-                                                                  v2056$19476
+                                                                  Hover.getTypeSignatureOnHover(
+                                                                        Position.TPosition.mk(
+                                                                              Thunk.<Integer>lazy(4), Thunk.<Integer>lazy(10)
+                                                                            ),
+                                                                        v2056$19580
+                                                                      )
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19477
-                                                          .apply(arg$20322))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19581
+                                                          .apply(arg$20382))
                                                     );
                                           })
                                     ))
@@ -1988,23 +1991,27 @@ final public static Lazy<QuickCheckGen.TGen<
     );
 final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWorld, Short>>shared(
       (Lazy<Func.U<RealWorld, Short>>)(() -> {
-            return (Func.U<RealWorld, Short>)((final Lazy<RealWorld> arg$20325) -> {
-                      final Global.TGlobal v2056$19541 = CompileExecutor.compile(
+            return (Func.U<RealWorld, Short>)((final Lazy<RealWorld> arg$20387) -> {
+                      final Global.TGlobal v2056$19667 = CompileGlobal.standardCompileGlobal
+                      .call().apply(arg$20387).call();
+                      final Func.U<RealWorld, Global.TGlobal> v2053$19686 = CompileExecutor.compile(
                             Thunk.<String/*<Character>*/>shared(
                                   (Lazy<String/*
                                     <Character>
                                   */>)(() -> "module HoverTest where\n\n" + ("import frege.compiler.Main(runpass)\n\n" + ("pass = runpass\n" + ("me = 42\n\n" + "main = do\n  a = \"Hello\"\n  println a"))))
                                 ),
-                            CompileGlobal.standardCompileGlobal.call()
-                          ).apply(arg$20325).call();
-                      final Func.U<RealWorld, Short> v4793$19563 = Prelude.<String/*<Character>*/>println(
-                            PreludeText.IShow_String.it, Global.TSubSt.code(Global.TGlobal.sub(v2056$19541)).toString()
+                            v2056$19667
                           );
-                      final short v4796$19565 = (short)v4793$19563.apply(arg$20325).call();
-                      final Func.U<RealWorld, Short> v4797$19566 = ((Func.U<RealWorld, Short>)((
-                        final Lazy<RealWorld> arg$20333
+                      final Global.TGlobal v2056$19689 = v2053$19686.apply(arg$20387)
+                      .call();
+                      final Func.U<RealWorld, Short> v4793$19711 = Prelude.<String/*<Character>*/>println(
+                            PreludeText.IShow_String.it, Global.TSubSt.code(Global.TGlobal.sub(v2056$19689)).toString()
+                          );
+                      final short v4796$19713 = (short)v4793$19711.apply(arg$20387).call();
+                      final Func.U<RealWorld, Short> v4797$19714 = ((Func.U<RealWorld, Short>)((
+                        final Lazy<RealWorld> arg$20395
                       ) -> {
-                            final short v4796$19596 = (short)Func.<RealWorld, Short>coerceU(
+                            final short v4796$19744 = (short)Func.<RealWorld, Short>coerceU(
                                   PreludeMonad.<Func.U<RealWorld, ?>, Tokens.TToken, Short, PreludeBase.TList<?>>$for(
                                         PreludeMonad.IMonad_ST.<RealWorld>mk(),
                                         PreludeList.IListSource_$lbrack$rbrack.<PreludeBase.TList<?>>mk(),
@@ -2015,92 +2022,47 @@ final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWor
                                                         (Lazy<PreludeBase.TList<
                                                           Tokens.TToken
                                                         >>)(() -> Tokens.IArrayElement_Token.listFromArray(
-                                                                  Global.TSubSt.toks(Global.TGlobal.sub(v2056$19541))
+                                                                  Global.TSubSt.toks(Global.TGlobal.sub(v2056$19689))
                                                                 ))
                                                       ).call())
                                             ),
                                         (Func.U<Tokens.TToken, Kind.U<Func.U<RealWorld, ?>, Short>>)((
-                                          final Lazy<Tokens.TToken> η$20332
+                                          final Lazy<Tokens.TToken> η$20394
                                         ) -> Thunk.<Kind.U<Func.U<RealWorld, ?>, Short>>shared(
                                                   (Lazy<Kind.U<Func.U<RealWorld, ?>, Short>>)(() -> (Kind.U<
                                                         Func.U<RealWorld, ?>, Short
                                                       >)Thunk.<Func.U<RealWorld, Short>>shared(
                                                             (Lazy<Func.U<RealWorld, Short>>)(() -> Prelude.<
                                                                   Tokens.TToken
-                                                                >println(Tokens.IShow_Token.it, η$20332.call()))
+                                                                >println(Tokens.IShow_Token.it, η$20394.call()))
                                                           ).call())
                                                 ))
                                       )
-                                ).apply(arg$20333).call();
-                            final Func.U<RealWorld, Short> v4797$19597 = ((Func.U<RealWorld, Short>)((
-                              final Lazy<RealWorld> arg$20327
+                                ).apply(arg$20395).call();
+                            final Func.U<RealWorld, Short> v4797$19745 = ((Func.U<RealWorld, Short>)((
+                              final Lazy<RealWorld> arg$20391
                             ) -> {
-                                  final PreludeBase.TMaybe<THover> v2056$19618 = Hover.getTypeSignatureOnHover(
-                                        PreludeMonad.IMonad_ST.<RealWorld, Global.TGlobal>pure(
-                                              v2056$19541
-                                            ),
-                                        Position.TPosition.mk(Thunk.<Integer>lazy(5), Thunk.<Integer>lazy(9))
-                                      ).apply(arg$20327).call();
-                                  final Func.U<RealWorld, Short> v4793$19640 = Prelude.<
-                                    PreludeBase.TMaybe<THover>
-                                  >println(new PreludeText.IShow_Maybe<THover>(IShow_Hover.it), v2056$19618);
-                                  final short v4796$19642 = (short)v4793$19640.apply(arg$20327)
-                                  .call();
-                                  final Func.U<RealWorld, Short> v4797$19643 = Thunk.<
+                                  final short v4796$19768 = (short)Prelude.<PreludeBase.TMaybe<THover>>println(
+                                        new PreludeText.IShow_Maybe<THover>(IShow_Hover.it),
+                                        Hover.getTypeSignatureOnHover(
+                                              Position.TPosition.mk(Thunk.<Integer>lazy(5), Thunk.<Integer>lazy(9)), v2056$19689
+                                            )
+                                      ).apply(arg$20391).call();
+                                  final Func.U<RealWorld, Short> v4797$19769 = Thunk.<
                                     Func.U<RealWorld, Short>
                                   >shared(
                                         (Lazy<Func.U<RealWorld, Short>>)(() -> Prelude.<
                                               String/*<Character>*/
                                             >println(PreludeText.IShow_String.it, "end"))
                                       ).call();
-                                  return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$19643.apply(arg$20327)));
+                                  return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$19769.apply(arg$20391)));
                                 })).call();
-                            return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$19597.apply(arg$20333)));
+                            return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$19745.apply(arg$20395)));
                           })).call();
-                      return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$19566.apply(arg$20325)));
+                      return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$19714.apply(arg$20387)));
                     });
           })
     );
-final public static Func.U<RealWorld, PreludeBase.TMaybe<THover>> compileAndGetTypeSignatureOnHover(
-  final Lazy<String/*<Character>*/> arg$1, final Lazy<Position.TPosition> arg$2
-) {
-  return (Func.U<RealWorld, PreludeBase.TMaybe<THover>>)((final Lazy<RealWorld> arg$20339) -> {
-            final Global.TGlobal v2056$20141 = CompileGlobal.standardCompileGlobal.call()
-            .apply(arg$20339).call();
-            final Func.U<RealWorld, Global.TGlobal> v2053$20160 = CompileExecutor.compile(
-                  arg$1, CompileGlobal.standardCompileGlobal.call()
-                );
-            final Global.TGlobal v2056$20163 = v2053$20160.apply(arg$20339).call();
-            final Func.U<RealWorld, PreludeBase.TMaybe<THover>> v2057$20164 = PreludeMonad.IMonad_ST.<
-              RealWorld, PreludeBase.TMaybe<THover>
-            >pure(
-                  Thunk.<PreludeBase.TMaybe<THover>>shared(
-                        (Lazy<PreludeBase.TMaybe<THover>>)(() -> PreludeBase.TMaybe.<THover>coerce(
-                                  Thunk.<Kind.U<PreludeBase.TMaybe<?>, THover>>shared(
-                                        (Lazy<Kind.U<PreludeBase.TMaybe<?>, THover>>)(() -> State.<
-                                              THover, PreludeBase.TMaybe<?>, Global.TGlobal
-                                            >evalStateT(
-                                                  Maybe.IMonad_Maybe.it,
-                                                  Thunk.<State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover>>shared(
-                                                        (Lazy<State.TStateT<
-                                                          Global.TGlobal, PreludeBase.TMaybe<?>, THover
-                                                        >>)(() -> Hover.getTypeOnHover(
-                                                                  arg$2
-                                                                ))
-                                                      ),
-                                                  v2056$20163
-                                                ))
-                                      ).call()
-                                ))
-                      )
-                );
-            return Thunk.<PreludeBase.TMaybe<THover>>nested(
-                      (Lazy<Lazy<PreludeBase.TMaybe<THover>>>)(() -> v2057$20164.apply(
-                                arg$20339
-                              ))
-                    );
-          });
-}
 
   public static void main(final java.lang.String[] argv) {
     try {

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/Hover.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/Hover.java
@@ -153,7 +153,7 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr",
-  time=1658516066199L, jmajor=11, jminor=-1,
+  time=1658602830271L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.compile.CompileExecutor",
     "ch.fhnw.thga.fregelanguageserver.compile.CompileGlobal", "frege.compiler.types.Global", "frege.data.List",
@@ -589,69 +589,74 @@ import frege.test.QuickCheckText;
   },
   symvs={
     @Meta.SymV(
-      offset=1772, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="tokenToQName"),
+      offset=1804, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="tokenToQName"),
       stri="s(u)", sig=35, depth=1, rkind=13
     ),
     @Meta.SymV(
-      offset=4568,
+      offset=5232,
       name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="shouldShowLocalConidDataConstructor"),
       stri="u", sig=36, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=3593,
+      offset=4055,
       name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="shouldShowLocalConidTypeSignature"),
       stri="u", sig=36, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=2630,
+      offset=2912,
       name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="shouldShowLocalVaridTypeSignature"),
       stri="u", sig=36, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=4082,
+      offset=4645,
       name=@Meta.QName(
         pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="shouldShowImportedConidTypeSignature"
       ),
       stri="u", sig=36, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=5099,
+      offset=5874,
       name=@Meta.QName(
         pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="shouldShowImportedConidDataConstructor"
       ),
       stri="u", sig=36, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=3103,
+      offset=3474,
       name=@Meta.QName(
         pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="shouldShowImportedVaridTypeSignature"
       ),
       stri="u", sig=36, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=5630, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="main"), stri="u",
+      offset=6516, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="main"), stri="u",
       sig=37, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=1140, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="getSymbolType"),
+      offset=2522, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="getTypeOnHover"),
       stri="s(u)", sig=39, depth=1, rkind=13
     ),
     @Meta.SymV(
-      offset=2261, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="getTypeOnHover"),
-      stri="s(u)", sig=41, depth=1, rkind=13
+      offset=2332,
+      name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="getTypeSignatureOnHover"),
+      stri="s(su)", sig=41, depth=2, rkind=13
     ),
     @Meta.SymV(
-      offset=1645, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="findSymbol"),
+      offset=1140, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="getSymbolType"),
       stri="s(u)", sig=43, depth=1, rkind=13
     ),
     @Meta.SymV(
-      offset=1262, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="findToken"), stri="s(u)",
-      sig=44, depth=1, rkind=13
+      offset=1665, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="findSymbol"),
+      stri="s(u)", sig=45, depth=1, rkind=13
     ),
     @Meta.SymV(
-      offset=1977,
+      offset=1272, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="findToken"), stri="s(u)",
+      sig=46, depth=1, rkind=13
+    ),
+    @Meta.SymV(
+      offset=2048,
       name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.Hover", base="compileAndGetTypeSignatureOnHover"),
-      stri="s(uu)", sig=45, depth=2, rkind=13
+      stri="s(uu)", sig=47, depth=2, rkind=13
     )
   },
   symls={
@@ -706,14 +711,15 @@ import frege.test.QuickCheckText;
     @Meta.Tau(kind=0, suba=32, subb=33),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.prelude.PreludeBase", base="()")}),
     @Meta.Tau(kind=0, suba=34, subb=35),
-    @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.compiler.types.Symbols", base="SymbolT")}),
-    @Meta.Tau(kind=0, suba=37, subb=23), @Meta.Tau(kind=0, suba=26, subb=3),
     @Meta.Tau(
       kind=2, suba=0,
       tcon={@Meta.QName(kind=0, pack="ch.fhnw.thga.fregelanguageserver.types.Position", base="Position")}
     ),
-    @Meta.Tau(kind=0, suba=26, subb=8), @Meta.Tau(kind=0, suba=26, subb=38), @Meta.Tau(kind=0, suba=26, subb=21),
-    @Meta.Tau(kind=0, suba=25, subb=8), @Meta.Tau(kind=0, suba=34, subb=44)
+    @Meta.Tau(kind=0, suba=26, subb=8), @Meta.Tau(kind=0, suba=34, subb=23), @Meta.Tau(kind=0, suba=25, subb=8),
+    @Meta.Tau(kind=0, suba=34, subb=40),
+    @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.compiler.types.Symbols", base="SymbolT")}),
+    @Meta.Tau(kind=0, suba=42, subb=23), @Meta.Tau(kind=0, suba=26, subb=3), @Meta.Tau(kind=0, suba=26, subb=43),
+    @Meta.Tau(kind=0, suba=26, subb=21)
   },
   rhos={
     @Meta.Rho(rhofun=false, rhotau=0), @Meta.Rho(rhofun=false, rhotau=3), @Meta.Rho(sigma=0, rhotau=1),
@@ -733,11 +739,12 @@ import frege.test.QuickCheckText;
     @Meta.Rho(sigma=0, rhotau=41), @Meta.Rho(rhofun=false, rhotau=20), @Meta.Rho(sigma=32, rhotau=0),
     @Meta.Rho(sigma=0, rhotau=44), @Meta.Rho(rhofun=false, rhotau=21), @Meta.Rho(rhofun=false, rhotau=28),
     @Meta.Rho(sigma=34, rhotau=47), @Meta.Rho(rhofun=false, rhotau=31), @Meta.Rho(rhofun=false, rhotau=36),
-    @Meta.Rho(rhofun=false, rhotau=38), @Meta.Rho(rhofun=false, rhotau=39), @Meta.Rho(sigma=38, rhotau=52),
-    @Meta.Rho(rhofun=false, rhotau=40), @Meta.Rho(rhofun=false, rhotau=41), @Meta.Rho(sigma=40, rhotau=55),
-    @Meta.Rho(rhofun=false, rhotau=27), @Meta.Rho(rhofun=false, rhotau=42), @Meta.Rho(sigma=42, rhotau=58),
-    @Meta.Rho(rhofun=false, rhotau=43), @Meta.Rho(sigma=40, rhotau=60), @Meta.Rho(rhofun=false, rhotau=45),
-    @Meta.Rho(sigma=40, rhotau=62), @Meta.Rho(sigma=3, rhotau=63)
+    @Meta.Rho(rhofun=false, rhotau=37), @Meta.Rho(rhofun=false, rhotau=38), @Meta.Rho(sigma=38, rhotau=52),
+    @Meta.Rho(rhofun=false, rhotau=39), @Meta.Rho(rhofun=false, rhotau=41), @Meta.Rho(sigma=38, rhotau=55),
+    @Meta.Rho(sigma=40, rhotau=56), @Meta.Rho(rhofun=false, rhotau=43), @Meta.Rho(rhofun=false, rhotau=44),
+    @Meta.Rho(sigma=42, rhotau=59), @Meta.Rho(rhofun=false, rhotau=27), @Meta.Rho(rhofun=false, rhotau=45),
+    @Meta.Rho(sigma=44, rhotau=62), @Meta.Rho(rhofun=false, rhotau=46), @Meta.Rho(sigma=38, rhotau=64),
+    @Meta.Rho(sigma=3, rhotau=56)
   },
   sigmas={
     @Meta.Sigma(rho=0), @Meta.Sigma(rho=2), @Meta.Sigma(rho=3), @Meta.Sigma(rho=1), @Meta.Sigma(rho=5),
@@ -748,8 +755,8 @@ import frege.test.QuickCheckText;
     @Meta.Sigma(rho=33), @Meta.Sigma(rho=34), @Meta.Sigma(rho=36), @Meta.Sigma(rho=37), @Meta.Sigma(rho=39),
     @Meta.Sigma(rho=40), @Meta.Sigma(rho=41), @Meta.Sigma(rho=42), @Meta.Sigma(rho=43), @Meta.Sigma(rho=45),
     @Meta.Sigma(rho=46), @Meta.Sigma(rho=48), @Meta.Sigma(rho=49), @Meta.Sigma(rho=50), @Meta.Sigma(rho=51),
-    @Meta.Sigma(rho=53), @Meta.Sigma(rho=54), @Meta.Sigma(rho=56), @Meta.Sigma(rho=57), @Meta.Sigma(rho=59),
-    @Meta.Sigma(rho=61), @Meta.Sigma(rho=64)
+    @Meta.Sigma(rho=53), @Meta.Sigma(rho=54), @Meta.Sigma(rho=57), @Meta.Sigma(rho=58), @Meta.Sigma(rho=60),
+    @Meta.Sigma(rho=61), @Meta.Sigma(rho=63), @Meta.Sigma(rho=65), @Meta.Sigma(rho=66)
   },
   exprs={@Meta.Expr()}
 )
@@ -792,10 +799,10 @@ final public static class IShow_FregeCodeBlock implements PreludeText.CShow<Stri
               Thunk.<String/*<Character>*/>lazy(", "),
               PreludeList.<String/*<Character>*/, String/*<Character>*/>map(
                     (Func.U<String/*<Character>*/, String/*<Character>*/>)((
-                      final Lazy<String/*<Character>*/> η$20143
+                      final Lazy<String/*<Character>*/> η$20217
                     ) -> Thunk.<String/*<Character>*/>shared(
                               (Lazy<String/*<Character>*/>)(() -> IShow_FregeCodeBlock.show(
-                                        η$20143.call()
+                                        η$20217.call()
                                       ))
                             )),
                     arg$1
@@ -843,19 +850,19 @@ final public static class IShow_Hover implements PreludeText.CShow<THover> {
     return IShow_Hover.showChars(arg$1.call());
   }
   final public static String/*<Character>*/ showsub(final THover arg$1) {
-    final String/*<Character>*/ a2$18193 = arg$1.mem$content.call();
-    final Range.TRange a1$18192 = arg$1.mem$range.call();
-    return ("(" + (((("Hover" + " ") + Range.IShow_Range.showsub(a1$18192)) + " ") + IShow_FregeCodeBlock.showsub(
-              a2$18193
+    final String/*<Character>*/ a2$18203 = arg$1.mem$content.call();
+    final Range.TRange a1$18202 = arg$1.mem$range.call();
+    return ("(" + (((("Hover" + " ") + Range.IShow_Range.showsub(a1$18202)) + " ") + IShow_FregeCodeBlock.showsub(
+              a2$18203
             ))) + ")";
   }
   final public static String/*<Character>*/ showList(final PreludeBase.TList<THover> arg$1, final String/*<Character>*/ arg$2) {
     return "[" + (PreludeText.joined(
               Thunk.<String/*<Character>*/>lazy(", "),
               PreludeList.<String/*<Character>*/, THover>map(
-                    (Func.U<THover, String/*<Character>*/>)((final Lazy<THover> η$20155) -> Thunk.<
+                    (Func.U<THover, String/*<Character>*/>)((final Lazy<THover> η$20229) -> Thunk.<
                           String/*<Character>*/
-                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_Hover.show(η$20155.call())))),
+                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_Hover.show(η$20229.call())))),
                     arg$1
                   )
             ).call() + ("]" + arg$2));
@@ -869,10 +876,10 @@ final public static class IShow_Hover implements PreludeText.CShow<THover> {
     return IShow_Hover.show(arg$1);
   }
   final public static String/*<Character>*/ show(final THover arg$1) {
-    final String/*<Character>*/ a2$18190 = arg$1.mem$content.call();
-    final Range.TRange a1$18189 = arg$1.mem$range.call();
-    return ((("Hover" + " ") + Range.IShow_Range.showsub(a1$18189)) + " ") + IShow_FregeCodeBlock.showsub(
-              a2$18190
+    final String/*<Character>*/ a2$18200 = arg$1.mem$content.call();
+    final Range.TRange a1$18199 = arg$1.mem$range.call();
+    return ((("Hover" + " ") + Range.IShow_Range.showsub(a1$18199)) + " ") + IShow_FregeCodeBlock.showsub(
+              a2$18200
             );
   }
   final public static PreludeBase.TList<Character> showChars(final THover arg$1) {
@@ -919,11 +926,11 @@ final public static class IEq_Hover implements PreludeBase.CEq<THover> {
     return IEq_Hover.$eq$eq(arg$1.call(), arg$2.call());
   }
   final public static int hashCode(final THover arg$1) {
-    final String/*<Character>*/ a2$18187 = arg$1.mem$content.call();
-    final Range.TRange a1$18186 = arg$1.mem$range.call();
+    final String/*<Character>*/ a2$18197 = arg$1.mem$content.call();
+    final Range.TRange a1$18196 = arg$1.mem$range.call();
     return (31 * ((31 * ((31 * 1) + RunTM.constructor(arg$1))) + Range.IEq_Range.hashCode(
-              a1$18186
-            ))) + IEq_FregeCodeBlock.hashCode(a2$18187);
+              a1$18196
+            ))) + IEq_FregeCodeBlock.hashCode(a2$18197);
   }
   final public static boolean $excl$eq(final THover arg$1, final THover arg$2) {
     if (IEq_Hover.$eq$eq(arg$1, arg$2)) {
@@ -934,11 +941,11 @@ final public static class IEq_Hover implements PreludeBase.CEq<THover> {
     }
   }
   final public static boolean $eq$eq(final THover arg$1, final THover arg$2) {
-    final String/*<Character>*/ µ$$18257 = arg$1.mem$content.call();
-    final Range.TRange µ$$18256 = arg$1.mem$range.call();
-    final String/*<Character>*/ µ$$18259 = arg$2.mem$content.call();
-    final Range.TRange µ$$18258 = arg$2.mem$range.call();
-    return Range.IEq_Range.$eq$eq(µ$$18256, µ$$18258) && IEq_FregeCodeBlock.$eq$eq(µ$$18257, µ$$18259);
+    final String/*<Character>*/ µ$$18267 = arg$1.mem$content.call();
+    final Range.TRange µ$$18266 = arg$1.mem$range.call();
+    final String/*<Character>*/ µ$$18269 = arg$2.mem$content.call();
+    final Range.TRange µ$$18268 = arg$2.mem$range.call();
+    return Range.IEq_Range.$eq$eq(µ$$18266, µ$$18268) && IEq_FregeCodeBlock.$eq$eq(µ$$18267, µ$$18269);
   }
 }
 final public static class THover implements frege.runtime.Value, Lazy<THover> {
@@ -979,8 +986,8 @@ final public static class THover implements frege.runtime.Value, Lazy<THover> {
     return true;
   }
   final public static Range.TRange range(final THover arg$1) {
-    final Range.TRange a1$18116 = arg$1.mem$range.call();
-    return a1$18116;
+    final Range.TRange a1$18117 = arg$1.mem$range.call();
+    return a1$18117;
   }
   final public static THover chg$range(final THover arg$1, final Lazy<Func.U<Range.TRange, Range.TRange>> arg$2) {
     return THover.mk(
@@ -999,8 +1006,8 @@ final public static class THover implements frege.runtime.Value, Lazy<THover> {
             );
   }
   final public static String/*<Character>*/ content(final THover arg$1) {
-    final String/*<Character>*/ a2$18105 = arg$1.mem$content.call();
-    return a2$18105;
+    final String/*<Character>*/ a2$18106 = arg$1.mem$content.call();
+    return a2$18106;
   }
 }
 public static abstract class TFregeCodeBlock  {
@@ -1026,12 +1033,12 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.
 ) {
   return State.TStateT.<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.TQName>mk(
             (Func.U<Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>>)((
-              final Lazy<Global.TGlobal> arg$20176
+              final Lazy<Global.TGlobal> arg$20250
             ) -> {
-                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$19191 =
-                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20176, arg$20176)
+                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$19236 =
+                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20250, arg$20250)
                   .call();
-                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, PreludeBase.TEither<Short, QNames.TQName>> $20178 =
+                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, PreludeBase.TEither<Short, QNames.TQName>> $20252 =
                   State.IMonadTrans_StateT.<
                     Global.TGlobal, PreludeBase.TEither<Short, QNames.TQName>, PreludeBase.TMaybe<?>
                   >lift(
@@ -1042,7 +1049,7 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.
                                   >)Thunk.<PreludeBase.TMaybe<PreludeBase.TEither<Short, QNames.TQName>>>shared(
                                         (Lazy<PreludeBase.TMaybe<
                                           PreludeBase.TEither<Short, QNames.TQName>
-                                        >>)(() -> Global.TGlobal.resolved(v2895$19191.mem1.call(), arg$1))
+                                        >>)(() -> Global.TGlobal.resolved(v2895$19236.mem1.call(), arg$1))
                                       ).call())
                             )
                       );
@@ -1051,22 +1058,22 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.
                     Kind.U<
                       PreludeBase.TMaybe<?>, PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal>
                     >
-                  > v7734$19220 = $20178.mem$run;
+                  > v7734$19265 = $20252.mem$run;
                   final PreludeBase.TMaybe<
                     PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal>
-                  > $20180 = RunTM.<
+                  > $20254 = RunTM.<
                     Func.U<
                       Global.TGlobal,
                       PreludeBase.TMaybe<PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal>>
                     >
-                  >cast(v7734$19220).apply(v2895$19191.mem2).call();
+                  >cast(v7734$19265).apply(v2895$19236.mem2).call();
                   final PreludeBase.TMaybe.DJust<
                     PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal>
-                  > $20181 = $20180.asJust();
-                  if ($20181 != null) {
-                    final PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal> v2895$19252 =
-                    $20181.mem1.call();
-                    final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.TQName> $20185 =
+                  > $20255 = $20254.asJust();
+                  if ($20255 != null) {
+                    final PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal> v2895$19297 =
+                    $20255.mem1.call();
+                    final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.TQName> $20259 =
                     State.IMonadTrans_StateT.<Global.TGlobal, QNames.TQName, PreludeBase.TMaybe<?>>lift(
                           Maybe.IMonad_Maybe.it,
                           Thunk.<Kind.U<PreludeBase.TMaybe<?>, QNames.TQName>>shared(
@@ -1077,29 +1084,29 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.
                                                 PreludeBase.TMaybe<QNames.TQName>, Short, QNames.TQName
                                               >either(
                                                     (Func.U<Short, PreludeBase.TMaybe<QNames.TQName>>)((
-                                                      final Lazy<Short> η$20183
+                                                      final Lazy<Short> η$20257
                                                     ) -> Thunk.<PreludeBase.TMaybe<QNames.TQName>>shared(
                                                               (Lazy<PreludeBase.TMaybe<
                                                                 QNames.TQName
                                                               >>)(() -> PreludeBase.<
                                                                     Short, PreludeBase.TMaybe<QNames.TQName>
                                                                   >$const(
-                                                                        PreludeBase.TMaybe.DNothing.<QNames.TQName>mk(), η$20183
+                                                                        PreludeBase.TMaybe.DNothing.<QNames.TQName>mk(), η$20257
                                                                       ))
                                                             )),
                                                     (Func.U<QNames.TQName, PreludeBase.TMaybe<QNames.TQName>>)((
-                                                      final Lazy<QNames.TQName> η$20184
+                                                      final Lazy<QNames.TQName> η$20258
                                                     ) -> PreludeBase.TMaybe.DJust.<QNames.TQName>mk(
-                                                              η$20184
+                                                              η$20258
                                                             )),
-                                                    v2895$19252.mem1.call()
+                                                    v2895$19297.mem1.call()
                                                   ))
                                         ).call())
                               )
                         );
                     final Func.U<
                       Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>
-                    > v7739$19225 = $20185.mem$run;
+                    > v7739$19270 = $20259.mem$run;
                     return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>>shared(
                               (Lazy<Kind.U<
                                 PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>
@@ -1113,14 +1120,14 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.
                                                 Global.TGlobal,
                                                 PreludeBase.TMaybe<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>
                                               >
-                                            >cast(v7739$19225).apply(v2895$19252.mem2))
+                                            >cast(v7739$19270).apply(v2895$19297.mem2))
                                       ).call())
                             );
                   }
                   final PreludeBase.TMaybe.DNothing<
                     PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal>
-                  > $20187 = $20180.asNothing();
-                  assert $20187 != null;
+                  > $20261 = $20254.asNothing();
+                  assert $20261 != null;
                   return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>>lazy(
                             (Kind.U<
                               PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>
@@ -1135,17 +1142,17 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/
   return State.TStateT.<Global.TGlobal, PreludeBase.TMaybe<?>, String/*<Character>*/>mk(
             (Func.U<
               Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>>
-            >)((final Lazy<Global.TGlobal> arg$20188) -> {
-                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$19649 =
-                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20188, arg$20188)
+            >)((final Lazy<Global.TGlobal> arg$20262) -> {
+                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$19967 =
+                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20262, arg$20262)
                   .call();
-                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/*<Character>*/> $20190 =
+                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/*<Character>*/> $20264 =
                   State.IMonad_StateT.<Global.TGlobal, PreludeBase.TMaybe<?>, String/*<Character>*/>pure(
-                        Maybe.IMonad_Maybe.it, frege.ide.Utilities.<Global.TGlobal>label(v2895$19649.mem1, arg$1.call())
+                        Maybe.IMonad_Maybe.it, frege.ide.Utilities.<Global.TGlobal>label(v2895$19967.mem1, arg$1.call())
                       );
                   final Func.U<
                     Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>>
-                  > v7739$19622 = $20190.mem$run;
+                  > v7739$19940 = $20264.mem$run;
                   return Thunk.<
                         Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>>
                       >shared(
@@ -1161,7 +1168,7 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/
                                               Global.TGlobal,
                                               PreludeBase.TMaybe<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>>
                                             >
-                                          >cast(v7739$19622).apply(v2895$19649.mem2))
+                                          >cast(v7739$19940).apply(v2895$19967.mem2))
                                     ).call())
                           );
                 })
@@ -1170,9 +1177,9 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/
 final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.TToken> findToken(
   final Lazy<Position.TPosition> arg$1
 ) {
-  final class Let$20192  {
-    final Let$20192 let$20192 = this;
-    final public boolean isHoverOverToken$18130(final Tokens.TToken arg$2) {
+  final class Let$20266  {
+    final Let$20266 let$20266 = this;
+    final public boolean isHoverOverToken$18131(final Tokens.TToken arg$2) {
       return (Position.TPosition.line(arg$1.call()) == Tokens.TToken.line(arg$2)) && ((Position.TPosition.character(
                 arg$1.call()
               ) < (Tokens.TToken.col(arg$2) + Tokens.TToken.value(arg$2).length())) && (Position.TPosition.character(
@@ -1180,15 +1187,15 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.
               ) >= Tokens.TToken.col(arg$2)));
     }
   }
-  final Let$20192 let$20192 = new Let$20192();
+  final Let$20266 let$20266 = new Let$20266();
   return State.TStateT.<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.TToken>mk(
             (Func.U<Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>>>)((
-              final Lazy<Global.TGlobal> arg$20193
+              final Lazy<Global.TGlobal> arg$20267
             ) -> {
-                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$20029 =
-                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20193, arg$20193)
+                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$20103 =
+                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20267, arg$20267)
                   .call();
-                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.TToken> $20196 =
+                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.TToken> $20270 =
                   State.IMonadTrans_StateT.<Global.TGlobal, Tokens.TToken, PreludeBase.TMaybe<?>>lift(
                         Maybe.IMonad_Maybe.it,
                         Thunk.<Kind.U<PreludeBase.TMaybe<?>, Tokens.TToken>>shared(
@@ -1199,11 +1206,11 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.
                                               Tokens.TToken
                                             >find(
                                                   (Func.U<Tokens.TToken, Boolean>)((
-                                                    final Lazy<Tokens.TToken> η$20195
+                                                    final Lazy<Tokens.TToken> η$20269
                                                   ) -> Thunk.<Boolean>shared(
-                                                            (Lazy<Boolean>)(() -> let$20192
-                                                                .isHoverOverToken$18130(
-                                                                      η$20195.call()
+                                                            (Lazy<Boolean>)(() -> let$20266
+                                                                .isHoverOverToken$18131(
+                                                                      η$20269.call()
                                                                     ))
                                                           )),
                                                   Thunk.<PreludeBase.TList<Tokens.TToken>>shared(
@@ -1212,7 +1219,7 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.
                                                         >>)(() -> Tokens.IArrayElement_Token.listFromArray(
                                                                   Global.TSubSt.toks(
                                                                         Global.TGlobal.sub(
-                                                                              v2895$20029.mem1
+                                                                              v2895$20103.mem1
                                                                               .call()
                                                                             )
                                                                       )
@@ -1224,7 +1231,7 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.
                       );
                   final Func.U<
                     Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>>
-                  > v7739$20002 = $20196.mem$run;
+                  > v7739$20076 = $20270.mem$run;
                   return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>>>shared(
                             (Lazy<Kind.U<
                               PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>
@@ -1238,7 +1245,7 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.
                                               Global.TGlobal,
                                               PreludeBase.TMaybe<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>>
                                             >
-                                          >cast(v7739$20002).apply(v2895$20029.mem2))
+                                          >cast(v7739$20076).apply(v2895$20103.mem2))
                                     ).call())
                           );
                 })
@@ -1251,11 +1258,11 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols
             (Func.U<
               Global.TGlobal,
               Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>>
-            >)((final Lazy<Global.TGlobal> arg$20198) -> {
-                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$19961 =
-                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20198, arg$20198)
+            >)((final Lazy<Global.TGlobal> arg$20272) -> {
+                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$20035 =
+                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20272, arg$20272)
                   .call();
-                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols.TSymbolT<Global.TGlobal>> $20200 =
+                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols.TSymbolT<Global.TGlobal>> $20274 =
                   State.IMonadTrans_StateT.<Global.TGlobal, Symbols.TSymbolT<Global.TGlobal>, PreludeBase.TMaybe<?>>lift(
                         Maybe.IMonad_Maybe.it,
                         Thunk.<Kind.U<PreludeBase.TMaybe<?>, Symbols.TSymbolT<Global.TGlobal>>>shared(
@@ -1264,14 +1271,14 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols
                                   >)Thunk.<PreludeBase.TMaybe<Symbols.TSymbolT<Global.TGlobal>>>nested(
                                         (Lazy<Lazy<PreludeBase.TMaybe<
                                           Symbols.TSymbolT<Global.TGlobal>
-                                        >>>)(() -> Global.TGlobal.find(v2895$19961.mem1.call(), arg$1.call()))
+                                        >>>)(() -> Global.TGlobal.find(v2895$20035.mem1.call(), arg$1.call()))
                                       ).call())
                             )
                       );
                   final Func.U<
                     Global.TGlobal,
                     Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>>
-                  > v7739$19934 = $20200.mem$run;
+                  > v7739$20008 = $20274.mem$run;
                   return Thunk.<
                         Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>>
                       >shared(
@@ -1291,7 +1298,7 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols
                                                 PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>
                                               >
                                             >
-                                          >cast(v7739$19934).apply(v2895$19961.mem2))
+                                          >cast(v7739$20008).apply(v2895$20035.mem2))
                                     ).call())
                           );
                 })
@@ -1302,88 +1309,88 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover>
 ) {
   return State.TStateT.<Global.TGlobal, PreludeBase.TMaybe<?>, THover>mk(
             (Func.U<Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>>)((
-              final Lazy<Global.TGlobal> arg$20202
+              final Lazy<Global.TGlobal> arg$20276
             ) -> {
-                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$19717 =
-                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20202, arg$20202)
+                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$19694 =
+                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20276, arg$20276)
                   .call();
-                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.TToken> $20204 =
+                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.TToken> $20278 =
                   Hover.findToken(arg$1);
                   final Func.U<
                     Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>>
-                  > v7734$19746 = $20204.mem$run;
-                  final PreludeBase.TMaybe<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>> $20206 =
+                  > v7734$19723 = $20278.mem$run;
+                  final PreludeBase.TMaybe<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>> $20280 =
                   RunTM.<Func.U<Global.TGlobal, PreludeBase.TMaybe<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>>>>cast(
-                        v7734$19746
-                      ).apply(v2895$19717.mem2).call();
-                  final PreludeBase.TMaybe.DJust<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>> $20207 =
-                  $20206.asJust();
-                  if ($20207 != null) {
-                    final PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal> v2895$19778 =
-                    $20207.mem1.call();
-                    final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.TQName> $20209 =
-                    Hover.tokenToQName(v2895$19778.mem1);
+                        v7734$19723
+                      ).apply(v2895$19694.mem2).call();
+                  final PreludeBase.TMaybe.DJust<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>> $20281 =
+                  $20280.asJust();
+                  if ($20281 != null) {
+                    final PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal> v2895$19755 =
+                    $20281.mem1.call();
+                    final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.TQName> $20283 =
+                    Hover.tokenToQName(v2895$19755.mem1);
                     final Func.U<
                       Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>
-                    > v7734$19790 = $20209.mem$run;
-                    final PreludeBase.TMaybe<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>> $20211 =
+                    > v7734$19767 = $20283.mem$run;
+                    final PreludeBase.TMaybe<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>> $20285 =
                     RunTM.<Func.U<Global.TGlobal, PreludeBase.TMaybe<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>>>cast(
-                          v7734$19790
-                        ).apply(v2895$19778.mem2).call();
-                    final PreludeBase.TMaybe.DJust<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>> $20212 =
-                    $20211.asJust();
-                    if ($20212 != null) {
-                      final PreludeBase.TTuple2<QNames.TQName, Global.TGlobal> v2895$19822 =
-                      $20212.mem1.call();
-                      final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols.TSymbolT<Global.TGlobal>> $20214 =
-                      Hover.findSymbol(v2895$19822.mem1);
+                          v7734$19767
+                        ).apply(v2895$19755.mem2).call();
+                    final PreludeBase.TMaybe.DJust<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>> $20286 =
+                    $20285.asJust();
+                    if ($20286 != null) {
+                      final PreludeBase.TTuple2<QNames.TQName, Global.TGlobal> v2895$19799 =
+                      $20286.mem1.call();
+                      final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols.TSymbolT<Global.TGlobal>> $20288 =
+                      Hover.findSymbol(v2895$19799.mem1);
                       final Func.U<
                         Global.TGlobal,
                         Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>>
-                      > v7734$19834 = $20214.mem$run;
-                      final PreludeBase.TMaybe<PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>> $20216 =
+                      > v7734$19811 = $20288.mem$run;
+                      final PreludeBase.TMaybe<PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>> $20290 =
                       RunTM.<
                         Func.U<
                           Global.TGlobal,
                           PreludeBase.TMaybe<PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>>
                         >
-                      >cast(v7734$19834).apply(v2895$19822.mem2).call();
+                      >cast(v7734$19811).apply(v2895$19799.mem2).call();
                       final PreludeBase.TMaybe.DJust<
                         PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>
-                      > $20217 = $20216.asJust();
-                      if ($20217 != null) {
-                        final PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal> v2895$19866 =
-                        $20217.mem1.call();
-                        final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/*<Character>*/> $20219 =
-                        Hover.getSymbolType(v2895$19866.mem1);
+                      > $20291 = $20290.asJust();
+                      if ($20291 != null) {
+                        final PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal> v2895$19843 =
+                        $20291.mem1.call();
+                        final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/*<Character>*/> $20293 =
+                        Hover.getSymbolType(v2895$19843.mem1);
                         final Func.U<
                           Global.TGlobal,
                           Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>>
-                        > v7734$19878 = $20219.mem$run;
-                        final PreludeBase.TMaybe<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>> $20221 =
+                        > v7734$19855 = $20293.mem$run;
+                        final PreludeBase.TMaybe<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>> $20295 =
                         RunTM.<
                           Func.U<Global.TGlobal, PreludeBase.TMaybe<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>>>
-                        >cast(v7734$19878).apply(v2895$19866.mem2).call();
-                        final PreludeBase.TMaybe.DJust<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>> $20222 =
-                        $20221.asJust();
-                        if ($20222 != null) {
-                          final PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal> v2895$19910 =
-                          $20222.mem1.call();
-                          final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover> $20224 =
+                        >cast(v7734$19855).apply(v2895$19843.mem2).call();
+                        final PreludeBase.TMaybe.DJust<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>> $20296 =
+                        $20295.asJust();
+                        if ($20296 != null) {
+                          final PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal> v2895$19887 =
+                          $20296.mem1.call();
+                          final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover> $20298 =
                           State.IMonad_StateT.<Global.TGlobal, PreludeBase.TMaybe<?>, THover>pure(
                                 Maybe.IMonad_Maybe.it,
                                 THover.mk(
                                       Thunk.<Range.TRange>shared(
                                             (Lazy<Range.TRange>)(() -> Range.tokenToRange(
-                                                      v2895$19778.mem1.call()
+                                                      v2895$19755.mem1.call()
                                                     ))
                                           ),
-                                      v2895$19910.mem1
+                                      v2895$19887.mem1
                                     )
                               );
                           final Func.U<
                             Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>
-                          > v7739$19883 = $20224.mem$run;
+                          > v7739$19860 = $20298.mem$run;
                           return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>>shared(
                                     (Lazy<Kind.U<
                                       PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>
@@ -1397,13 +1404,13 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover>
                                                       Global.TGlobal,
                                                       PreludeBase.TMaybe<PreludeBase.TTuple2<THover, Global.TGlobal>>
                                                     >
-                                                  >cast(v7739$19883).apply(v2895$19910.mem2))
+                                                  >cast(v7739$19860).apply(v2895$19887.mem2))
                                             ).call())
                                   );
                         }
-                        final PreludeBase.TMaybe.DNothing<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>> $20226 =
-                        $20221.asNothing();
-                        assert $20226 != null;
+                        final PreludeBase.TMaybe.DNothing<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>> $20300 =
+                        $20295.asNothing();
+                        assert $20300 != null;
                         return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>>lazy(
                                   (Kind.U<
                                     PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>
@@ -1412,26 +1419,26 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover>
                       }
                       final PreludeBase.TMaybe.DNothing<
                         PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>
-                      > $20227 = $20216.asNothing();
-                      assert $20227 != null;
+                      > $20301 = $20290.asNothing();
+                      assert $20301 != null;
                       return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>>lazy(
                                 (Kind.U<
                                   PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>
                                 >)PreludeBase.TMaybe.DNothing.<PreludeBase.TTuple2<THover, Global.TGlobal>>mk()
                               );
                     }
-                    final PreludeBase.TMaybe.DNothing<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>> $20228 =
-                    $20211.asNothing();
-                    assert $20228 != null;
+                    final PreludeBase.TMaybe.DNothing<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>> $20302 =
+                    $20285.asNothing();
+                    assert $20302 != null;
                     return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>>lazy(
                               (Kind.U<
                                 PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>
                               >)PreludeBase.TMaybe.DNothing.<PreludeBase.TTuple2<THover, Global.TGlobal>>mk()
                             );
                   }
-                  final PreludeBase.TMaybe.DNothing<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>> $20229 =
-                  $20206.asNothing();
-                  assert $20229 != null;
+                  final PreludeBase.TMaybe.DNothing<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>> $20303 =
+                  $20280.asNothing();
+                  assert $20303 != null;
                   return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>>lazy(
                             (Kind.U<
                               PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>
@@ -1440,17 +1447,12 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover>
                 })
           );
 }
-final public static Func.U<RealWorld, PreludeBase.TMaybe<THover>> compileAndGetTypeSignatureOnHover(
-  final Lazy<String/*<Character>*/> arg$1, final Lazy<Position.TPosition> arg$2
+final public static Func.U<RealWorld, PreludeBase.TMaybe<THover>> getTypeSignatureOnHover(
+  final Func.U<RealWorld, Global.TGlobal> arg$1, final Lazy<Position.TPosition> arg$2
 ) {
-  return (Func.U<RealWorld, PreludeBase.TMaybe<THover>>)((final Lazy<RealWorld> arg$20230) -> {
-            final Global.TGlobal v2056$20067 = CompileGlobal.standardCompileGlobal.call()
-            .apply(arg$20230).call();
-            final Func.U<RealWorld, Global.TGlobal> v2053$20086 = CompileExecutor.compile(
-                  arg$1, CompileGlobal.standardCompileGlobal.call()
-                );
-            final Global.TGlobal v2056$20089 = v2053$20086.apply(arg$20230).call();
-            final Func.U<RealWorld, PreludeBase.TMaybe<THover>> v2057$20090 = PreludeMonad.IMonad_ST.<
+  return (Func.U<RealWorld, PreludeBase.TMaybe<THover>>)((final Lazy<RealWorld> arg$20304) -> {
+            final Global.TGlobal v2056$19908 = arg$1.apply(arg$20304).call();
+            final Func.U<RealWorld, PreludeBase.TMaybe<THover>> v2057$19909 = PreludeMonad.IMonad_ST.<
               RealWorld, PreludeBase.TMaybe<THover>
             >pure(
                   Thunk.<PreludeBase.TMaybe<THover>>shared(
@@ -1467,15 +1469,15 @@ final public static Func.U<RealWorld, PreludeBase.TMaybe<THover>> compileAndGetT
                                                                   arg$2
                                                                 ))
                                                       ),
-                                                  v2056$20089
+                                                  v2056$19908
                                                 ))
                                       ).call()
                                 ))
                       )
                 );
             return Thunk.<PreludeBase.TMaybe<THover>>nested(
-                      (Lazy<Lazy<PreludeBase.TMaybe<THover>>>)(() -> v2057$20090.apply(
-                                arg$20230
+                      (Lazy<Lazy<PreludeBase.TMaybe<THover>>>)(() -> v2057$19909.apply(
+                                arg$20304
                               ))
                     );
           });
@@ -1493,17 +1495,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20235) -> {
-                                            final PreludeBase.TMaybe<THover> v2056$19359 =
-                                            Hover.compileAndGetTypeSignatureOnHover(
-                                                  Thunk.<String/*<Character>*/>shared(
-                                                        (Lazy<String/*
-                                                          <Character>
-                                                        */>)(() -> "module HoverTest where\n\n" + "simplyString = \"Hello\"")
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20307) -> {
+                                            final PreludeBase.TMaybe<THover> v2056$19404 =
+                                            Hover.getTypeSignatureOnHover(
+                                                  CompileExecutor.compile(
+                                                        Thunk.<String/*<Character>*/>shared(
+                                                              (Lazy<String/*
+                                                                <Character>
+                                                              */>)(() -> "module HoverTest where\n\n" + "simplyString = \"Hello\"")
+                                                            ),
+                                                        CompileGlobal.standardCompileGlobal
+                                                        .call()
                                                       ),
                                                   Position.TPosition.mk(Thunk.<Integer>lazy(3), Thunk.<Integer>lazy(3))
-                                                ).apply(arg$20235).call();
-                                            final Func.U<RealWorld, Boolean> v2057$19360 =
+                                                ).apply(arg$20307).call();
+                                            final Func.U<RealWorld, Boolean> v2057$19405 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Maybe.IEq_Maybe.<
@@ -1545,13 +1551,13 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                                   )
                                                                             )
                                                                       ),
-                                                                  v2056$19359
+                                                                  v2056$19404
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19360
-                                                          .apply(arg$20235))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19405
+                                                          .apply(arg$20307))
                                                     );
                                           })
                                     ))
@@ -1572,17 +1578,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20238) -> {
-                                            final PreludeBase.TMaybe<THover> v2056$19323 =
-                                            Hover.compileAndGetTypeSignatureOnHover(
-                                                  Thunk.<String/*<Character>*/>shared(
-                                                        (Lazy<String/*
-                                                          <Character>
-                                                        */>)(() -> "module HoverTest where\n\n" + "data MyMaybe a = MyNothing | MyJust a\n")
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20310) -> {
+                                            final PreludeBase.TMaybe<THover> v2056$19368 =
+                                            Hover.getTypeSignatureOnHover(
+                                                  CompileExecutor.compile(
+                                                        Thunk.<String/*<Character>*/>shared(
+                                                              (Lazy<String/*
+                                                                <Character>
+                                                              */>)(() -> "module HoverTest where\n\n" + "data MyMaybe a = MyNothing | MyJust a\n")
+                                                            ),
+                                                        CompileGlobal.standardCompileGlobal
+                                                        .call()
                                                       ),
                                                   Position.TPosition.mk(Thunk.<Integer>lazy(3), Thunk.<Integer>lazy(7))
-                                                ).apply(arg$20238).call();
-                                            final Func.U<RealWorld, Boolean> v2057$19324 =
+                                                ).apply(arg$20310).call();
+                                            final Func.U<RealWorld, Boolean> v2057$19369 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Maybe.IEq_Maybe.<
@@ -1624,13 +1634,13 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                                   )
                                                                             )
                                                                       ),
-                                                                  v2056$19323
+                                                                  v2056$19368
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19324
-                                                          .apply(arg$20238))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19369
+                                                          .apply(arg$20310))
                                                     );
                                           })
                                     ))
@@ -1651,17 +1661,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20241) -> {
-                                            final PreludeBase.TMaybe<THover> v2056$19287 =
-                                            Hover.compileAndGetTypeSignatureOnHover(
-                                                  Thunk.<String/*<Character>*/>shared(
-                                                        (Lazy<String/*
-                                                          <Character>
-                                                        */>)(() -> "module HoverTest where\n\n" + ("data MyMaybe a = MyNothing | MyJust a\n" + "res = MyJust 42"))
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20313) -> {
+                                            final PreludeBase.TMaybe<THover> v2056$19332 =
+                                            Hover.getTypeSignatureOnHover(
+                                                  CompileExecutor.compile(
+                                                        Thunk.<String/*<Character>*/>shared(
+                                                              (Lazy<String/*
+                                                                <Character>
+                                                              */>)(() -> "module HoverTest where\n\n" + ("data MyMaybe a = MyNothing | MyJust a\n" + "res = MyJust 42"))
+                                                            ),
+                                                        CompileGlobal.standardCompileGlobal
+                                                        .call()
                                                       ),
                                                   Position.TPosition.mk(Thunk.<Integer>lazy(4), Thunk.<Integer>lazy(8))
-                                                ).apply(arg$20241).call();
-                                            final Func.U<RealWorld, Boolean> v2057$19288 =
+                                                ).apply(arg$20313).call();
+                                            final Func.U<RealWorld, Boolean> v2057$19333 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Maybe.IEq_Maybe.<
@@ -1703,13 +1717,13 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                                   )
                                                                             )
                                                                       ),
-                                                                  v2056$19287
+                                                                  v2056$19332
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19288
-                                                          .apply(arg$20241))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19333
+                                                          .apply(arg$20313))
                                                     );
                                           })
                                     ))
@@ -1732,17 +1746,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20244) -> {
-                                            final PreludeBase.TMaybe<THover> v2056$19467 =
-                                            Hover.compileAndGetTypeSignatureOnHover(
-                                                  Thunk.<String/*<Character>*/>shared(
-                                                        (Lazy<String/*
-                                                          <Character>
-                                                        */>)(() -> "module HoverTest where\n\n" + "main = println \"Hello\"")
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20316) -> {
+                                            final PreludeBase.TMaybe<THover> v2056$19512 =
+                                            Hover.getTypeSignatureOnHover(
+                                                  CompileExecutor.compile(
+                                                        Thunk.<String/*<Character>*/>shared(
+                                                              (Lazy<String/*
+                                                                <Character>
+                                                              */>)(() -> "module HoverTest where\n\n" + "main = println \"Hello\"")
+                                                            ),
+                                                        CompileGlobal.standardCompileGlobal
+                                                        .call()
                                                       ),
                                                   Position.TPosition.mk(Thunk.<Integer>lazy(3), Thunk.<Integer>lazy(9))
-                                                ).apply(arg$20244).call();
-                                            final Func.U<RealWorld, Boolean> v2057$19468 =
+                                                ).apply(arg$20316).call();
+                                            final Func.U<RealWorld, Boolean> v2057$19513 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Maybe.IEq_Maybe.<
@@ -1784,13 +1802,13 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                                   )
                                                                             )
                                                                       ),
-                                                                  v2056$19467
+                                                                  v2056$19512
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19468
-                                                          .apply(arg$20244))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19513
+                                                          .apply(arg$20316))
                                                     );
                                           })
                                     ))
@@ -1813,17 +1831,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20247) -> {
-                                            final PreludeBase.TMaybe<THover> v2056$19395 =
-                                            Hover.compileAndGetTypeSignatureOnHover(
-                                                  Thunk.<String/*<Character>*/>shared(
-                                                        (Lazy<String/*
-                                                          <Character>
-                                                        */>)(() -> "module HoverTest where\n\n" + "import frege.data.Maybe(Maybe)")
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20319) -> {
+                                            final PreludeBase.TMaybe<THover> v2056$19440 =
+                                            Hover.getTypeSignatureOnHover(
+                                                  CompileExecutor.compile(
+                                                        Thunk.<String/*<Character>*/>shared(
+                                                              (Lazy<String/*
+                                                                <Character>
+                                                              */>)(() -> "module HoverTest where\n\n" + "import frege.data.Maybe(Maybe)")
+                                                            ),
+                                                        CompileGlobal.standardCompileGlobal
+                                                        .call()
                                                       ),
                                                   Position.TPosition.mk(Thunk.<Integer>lazy(3), Thunk.<Integer>lazy(27))
-                                                ).apply(arg$20247).call();
-                                            final Func.U<RealWorld, Boolean> v2057$19396 =
+                                                ).apply(arg$20319).call();
+                                            final Func.U<RealWorld, Boolean> v2057$19441 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Maybe.IEq_Maybe.<
@@ -1865,13 +1887,13 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                                   )
                                                                             )
                                                                       ),
-                                                                  v2056$19395
+                                                                  v2056$19440
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19396
-                                                          .apply(arg$20247))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19441
+                                                          .apply(arg$20319))
                                                     );
                                           })
                                     ))
@@ -1894,17 +1916,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20250) -> {
-                                            final PreludeBase.TMaybe<THover> v2056$19431 =
-                                            Hover.compileAndGetTypeSignatureOnHover(
-                                                  Thunk.<String/*<Character>*/>shared(
-                                                        (Lazy<String/*
-                                                          <Character>
-                                                        */>)(() -> "module HoverTest where\n\n" + ("import frege.data.Maybe(Maybe, Just)\n" + "res = Just 42"))
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20322) -> {
+                                            final PreludeBase.TMaybe<THover> v2056$19476 =
+                                            Hover.getTypeSignatureOnHover(
+                                                  CompileExecutor.compile(
+                                                        Thunk.<String/*<Character>*/>shared(
+                                                              (Lazy<String/*
+                                                                <Character>
+                                                              */>)(() -> "module HoverTest where\n\n" + ("import frege.data.Maybe(Maybe, Just)\n" + "res = Just 42"))
+                                                            ),
+                                                        CompileGlobal.standardCompileGlobal
+                                                        .call()
                                                       ),
                                                   Position.TPosition.mk(Thunk.<Integer>lazy(4), Thunk.<Integer>lazy(10))
-                                                ).apply(arg$20250).call();
-                                            final Func.U<RealWorld, Boolean> v2057$19432 =
+                                                ).apply(arg$20322).call();
+                                            final Func.U<RealWorld, Boolean> v2057$19477 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Maybe.IEq_Maybe.<
@@ -1946,13 +1972,13 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                                   )
                                                                             )
                                                                       ),
-                                                                  v2056$19431
+                                                                  v2056$19476
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19432
-                                                          .apply(arg$20250))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19477
+                                                          .apply(arg$20322))
                                                     );
                                           })
                                     ))
@@ -1962,23 +1988,23 @@ final public static Lazy<QuickCheckGen.TGen<
     );
 final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWorld, Short>>shared(
       (Lazy<Func.U<RealWorld, Short>>)(() -> {
-            final Lazy<String/*<Character>*/> fregeCode$18167 = Thunk.<String/*<Character>*/>shared(
-                  (Lazy<String/*
-                    <Character>
-                  */>)(() -> "module HoverTest where\n\n" + ("import frege.compiler.Main(runpass)\n\n" + ("pass = runpass\n" + ("me = 42\n\n" + "main = do\n  a = \"Hello\"\n  println a"))))
-                );
-            return (Func.U<RealWorld, Short>)((final Lazy<RealWorld> arg$20253) -> {
-                      final Global.TGlobal v2056$19496 = CompileExecutor.compile(
-                            fregeCode$18167, CompileGlobal.standardCompileGlobal.call()
-                          ).apply(arg$20253).call();
-                      final Func.U<RealWorld, Short> v4793$19518 = Prelude.<String/*<Character>*/>println(
-                            PreludeText.IShow_String.it, Global.TSubSt.code(Global.TGlobal.sub(v2056$19496)).toString()
+            return (Func.U<RealWorld, Short>)((final Lazy<RealWorld> arg$20325) -> {
+                      final Global.TGlobal v2056$19541 = CompileExecutor.compile(
+                            Thunk.<String/*<Character>*/>shared(
+                                  (Lazy<String/*
+                                    <Character>
+                                  */>)(() -> "module HoverTest where\n\n" + ("import frege.compiler.Main(runpass)\n\n" + ("pass = runpass\n" + ("me = 42\n\n" + "main = do\n  a = \"Hello\"\n  println a"))))
+                                ),
+                            CompileGlobal.standardCompileGlobal.call()
+                          ).apply(arg$20325).call();
+                      final Func.U<RealWorld, Short> v4793$19563 = Prelude.<String/*<Character>*/>println(
+                            PreludeText.IShow_String.it, Global.TSubSt.code(Global.TGlobal.sub(v2056$19541)).toString()
                           );
-                      final short v4796$19520 = (short)v4793$19518.apply(arg$20253).call();
-                      final Func.U<RealWorld, Short> v4797$19521 = ((Func.U<RealWorld, Short>)((
-                        final Lazy<RealWorld> arg$20261
+                      final short v4796$19565 = (short)v4793$19563.apply(arg$20325).call();
+                      final Func.U<RealWorld, Short> v4797$19566 = ((Func.U<RealWorld, Short>)((
+                        final Lazy<RealWorld> arg$20333
                       ) -> {
-                            final short v4796$19551 = (short)Func.<RealWorld, Short>coerceU(
+                            final short v4796$19596 = (short)Func.<RealWorld, Short>coerceU(
                                   PreludeMonad.<Func.U<RealWorld, ?>, Tokens.TToken, Short, PreludeBase.TList<?>>$for(
                                         PreludeMonad.IMonad_ST.<RealWorld>mk(),
                                         PreludeList.IListSource_$lbrack$rbrack.<PreludeBase.TList<?>>mk(),
@@ -1989,49 +2015,92 @@ final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWor
                                                         (Lazy<PreludeBase.TList<
                                                           Tokens.TToken
                                                         >>)(() -> Tokens.IArrayElement_Token.listFromArray(
-                                                                  Global.TSubSt.toks(Global.TGlobal.sub(v2056$19496))
+                                                                  Global.TSubSt.toks(Global.TGlobal.sub(v2056$19541))
                                                                 ))
                                                       ).call())
                                             ),
                                         (Func.U<Tokens.TToken, Kind.U<Func.U<RealWorld, ?>, Short>>)((
-                                          final Lazy<Tokens.TToken> η$20260
+                                          final Lazy<Tokens.TToken> η$20332
                                         ) -> Thunk.<Kind.U<Func.U<RealWorld, ?>, Short>>shared(
                                                   (Lazy<Kind.U<Func.U<RealWorld, ?>, Short>>)(() -> (Kind.U<
                                                         Func.U<RealWorld, ?>, Short
                                                       >)Thunk.<Func.U<RealWorld, Short>>shared(
                                                             (Lazy<Func.U<RealWorld, Short>>)(() -> Prelude.<
                                                                   Tokens.TToken
-                                                                >println(Tokens.IShow_Token.it, η$20260.call()))
+                                                                >println(Tokens.IShow_Token.it, η$20332.call()))
                                                           ).call())
                                                 ))
                                       )
-                                ).apply(arg$20261).call();
-                            final Func.U<RealWorld, Short> v4797$19552 = ((Func.U<RealWorld, Short>)((
-                              final Lazy<RealWorld> arg$20255
+                                ).apply(arg$20333).call();
+                            final Func.U<RealWorld, Short> v4797$19597 = ((Func.U<RealWorld, Short>)((
+                              final Lazy<RealWorld> arg$20327
                             ) -> {
-                                  final PreludeBase.TMaybe<THover> v2056$19573 = Hover.compileAndGetTypeSignatureOnHover(
-                                        fregeCode$18167, Position.TPosition.mk(Thunk.<Integer>lazy(5), Thunk.<Integer>lazy(9))
-                                      ).apply(arg$20255).call();
-                                  final Func.U<RealWorld, Short> v4793$19595 = Prelude.<
+                                  final PreludeBase.TMaybe<THover> v2056$19618 = Hover.getTypeSignatureOnHover(
+                                        PreludeMonad.IMonad_ST.<RealWorld, Global.TGlobal>pure(
+                                              v2056$19541
+                                            ),
+                                        Position.TPosition.mk(Thunk.<Integer>lazy(5), Thunk.<Integer>lazy(9))
+                                      ).apply(arg$20327).call();
+                                  final Func.U<RealWorld, Short> v4793$19640 = Prelude.<
                                     PreludeBase.TMaybe<THover>
-                                  >println(new PreludeText.IShow_Maybe<THover>(IShow_Hover.it), v2056$19573);
-                                  final short v4796$19597 = (short)v4793$19595.apply(arg$20255)
+                                  >println(new PreludeText.IShow_Maybe<THover>(IShow_Hover.it), v2056$19618);
+                                  final short v4796$19642 = (short)v4793$19640.apply(arg$20327)
                                   .call();
-                                  final Func.U<RealWorld, Short> v4797$19598 = Thunk.<
+                                  final Func.U<RealWorld, Short> v4797$19643 = Thunk.<
                                     Func.U<RealWorld, Short>
                                   >shared(
                                         (Lazy<Func.U<RealWorld, Short>>)(() -> Prelude.<
                                               String/*<Character>*/
                                             >println(PreludeText.IShow_String.it, "end"))
                                       ).call();
-                                  return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$19598.apply(arg$20255)));
+                                  return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$19643.apply(arg$20327)));
                                 })).call();
-                            return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$19552.apply(arg$20261)));
+                            return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$19597.apply(arg$20333)));
                           })).call();
-                      return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$19521.apply(arg$20253)));
+                      return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$19566.apply(arg$20325)));
                     });
           })
     );
+final public static Func.U<RealWorld, PreludeBase.TMaybe<THover>> compileAndGetTypeSignatureOnHover(
+  final Lazy<String/*<Character>*/> arg$1, final Lazy<Position.TPosition> arg$2
+) {
+  return (Func.U<RealWorld, PreludeBase.TMaybe<THover>>)((final Lazy<RealWorld> arg$20339) -> {
+            final Global.TGlobal v2056$20141 = CompileGlobal.standardCompileGlobal.call()
+            .apply(arg$20339).call();
+            final Func.U<RealWorld, Global.TGlobal> v2053$20160 = CompileExecutor.compile(
+                  arg$1, CompileGlobal.standardCompileGlobal.call()
+                );
+            final Global.TGlobal v2056$20163 = v2053$20160.apply(arg$20339).call();
+            final Func.U<RealWorld, PreludeBase.TMaybe<THover>> v2057$20164 = PreludeMonad.IMonad_ST.<
+              RealWorld, PreludeBase.TMaybe<THover>
+            >pure(
+                  Thunk.<PreludeBase.TMaybe<THover>>shared(
+                        (Lazy<PreludeBase.TMaybe<THover>>)(() -> PreludeBase.TMaybe.<THover>coerce(
+                                  Thunk.<Kind.U<PreludeBase.TMaybe<?>, THover>>shared(
+                                        (Lazy<Kind.U<PreludeBase.TMaybe<?>, THover>>)(() -> State.<
+                                              THover, PreludeBase.TMaybe<?>, Global.TGlobal
+                                            >evalStateT(
+                                                  Maybe.IMonad_Maybe.it,
+                                                  Thunk.<State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover>>shared(
+                                                        (Lazy<State.TStateT<
+                                                          Global.TGlobal, PreludeBase.TMaybe<?>, THover
+                                                        >>)(() -> Hover.getTypeOnHover(
+                                                                  arg$2
+                                                                ))
+                                                      ),
+                                                  v2056$20163
+                                                ))
+                                      ).call()
+                                ))
+                      )
+                );
+            return Thunk.<PreludeBase.TMaybe<THover>>nested(
+                      (Lazy<Lazy<PreludeBase.TMaybe<THover>>>)(() -> v2057$20164.apply(
+                                arg$20339
+                              ))
+                    );
+          });
+}
 
   public static void main(final java.lang.String[] argv) {
     try {

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/HoverLSP.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/HoverLSP.java
@@ -156,7 +156,7 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/HoverLSP.fr",
-  time=1658602830858L, jmajor=11, jminor=-1,
+  time=1658948164148L, jmajor=11, jminor=-1,
   imps={
     "frege.compiler.types.Global", "ch.fhnw.thga.fregelanguageserver.hover.Hover",
     "ch.fhnw.thga.fregelanguageserver.lsp4j.PositionLSP4J", "frege.Prelude", "frege.prelude.PreludeArrays",
@@ -171,12 +171,12 @@ import frege.test.QuickCheckText;
   symas={}, symcs={}, symis={},
   symts={
     @Meta.SymT(
-      offset=407,
+      offset=372,
       name=@Meta.QName(kind=0, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="MarkupContentLSP"), typ=0,
       kind=4, cons={}, lnks={},
       funs={
         @Meta.SymV(
-          offset=492,
+          offset=457,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="MarkupContentLSP", member="new"
           ),
@@ -186,19 +186,19 @@ import frege.test.QuickCheckText;
       pur=true, nativ="org.eclipse.lsp4j.MarkupContent"
     ),
     @Meta.SymT(
-      offset=542,
+      offset=507,
       name=@Meta.QName(kind=0, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="MarkupKindLSP"), typ=3,
       kind=4, cons={}, lnks={},
       funs={
         @Meta.SymV(
-          offset=688,
+          offset=653,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="MarkupKindLSP", member="markdown"
           ),
           stri="s", sig=1, nativ="org.eclipse.lsp4j.MarkupKind.MARKDOWN", depth=0, rkind=9
         ),
         @Meta.SymV(
-          offset=616,
+          offset=581,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="MarkupKindLSP", member="plaintext"
           ),
@@ -208,18 +208,18 @@ import frege.test.QuickCheckText;
       pur=true, nativ="org.eclipse.lsp4j.MarkupKind"
     ),
     @Meta.SymT(
-      offset=755, name=@Meta.QName(kind=0, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="HoverLSP"),
+      offset=720, name=@Meta.QName(kind=0, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="HoverLSP"),
       typ=4, kind=4, cons={}, lnks={},
       funs={
         @Meta.SymV(
-          offset=877,
+          offset=842,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="HoverLSP", member="fromHover"
           ),
           stri="s(s(ss))", sig=6, depth=1, rkind=13
         ),
         @Meta.SymV(
-          offset=824,
+          offset=789,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="HoverLSP", member="new"
           ),
@@ -231,20 +231,13 @@ import frege.test.QuickCheckText;
   },
   symvs={
     @Meta.SymV(
-      offset=1601, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="main"), stri="u",
+      offset=1280, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="main"), stri="u",
       sig=9, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=1084,
+      offset=1049,
       name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="getTypeSignatureOnHoverLSP"),
-      stri="s(su)", sig=12, depth=2, rkind=13
-    ),
-    @Meta.SymV(
-      offset=1326,
-      name=@Meta.QName(
-        pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="compileAndGetTypeSignatureOnHoverLSP"
-      ),
-      stri="s(uu)", sig=13, depth=2, rkind=13
+      stri="s(uu)", sig=12, depth=2, rkind=13
     )
   },
   symls={},
@@ -276,27 +269,26 @@ import frege.test.QuickCheckText;
     @Meta.Tau(kind=0, suba=9, subb=10),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.prelude.PreludeBase", base="()")}),
     @Meta.Tau(kind=0, suba=11, subb=12),
-    @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.compiler.types.Global", base="Global")}),
-    @Meta.Tau(kind=0, suba=11, subb=14),
     @Meta.Tau(
       kind=2, suba=0,
       tcon={@Meta.QName(kind=0, pack="ch.fhnw.thga.fregelanguageserver.lsp4j.PositionLSP4J", base="PositionLSP")}
     ),
+    @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.compiler.types.Global", base="Global")}),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.prelude.PreludeBase", base="Maybe")}),
-    @Meta.Tau(kind=0, suba=17, subb=6), @Meta.Tau(kind=0, suba=11, subb=18)
+    @Meta.Tau(kind=0, suba=16, subb=6)
   },
   rhos={
     @Meta.Rho(rhofun=false, rhotau=0), @Meta.Rho(rhofun=false, rhotau=3), @Meta.Rho(sigma=1, rhotau=0),
     @Meta.Rho(sigma=1, rhotau=2), @Meta.Rho(rhofun=false, rhotau=5), @Meta.Rho(rhofun=false, rhotau=6),
     @Meta.Rho(rhofun=false, rhotau=7), @Meta.Rho(sigma=5, rhotau=5), @Meta.Rho(rhofun=false, rhotau=8),
     @Meta.Rho(sigma=7, rhotau=5), @Meta.Rho(sigma=0, rhotau=9), @Meta.Rho(rhofun=false, rhotau=13),
-    @Meta.Rho(rhofun=false, rhotau=15), @Meta.Rho(rhofun=false, rhotau=16), @Meta.Rho(rhofun=false, rhotau=19),
-    @Meta.Rho(sigma=11, rhotau=14), @Meta.Rho(sigma=10, rhotau=15), @Meta.Rho(sigma=1, rhotau=15)
+    @Meta.Rho(rhofun=false, rhotau=14), @Meta.Rho(rhofun=false, rhotau=15), @Meta.Rho(rhofun=false, rhotau=17),
+    @Meta.Rho(sigma=11, rhotau=14), @Meta.Rho(sigma=10, rhotau=15)
   },
   sigmas={
     @Meta.Sigma(rho=0), @Meta.Sigma(rho=1), @Meta.Sigma(rho=3), @Meta.Sigma(rho=4), @Meta.Sigma(rho=5),
     @Meta.Sigma(rho=6), @Meta.Sigma(rho=7), @Meta.Sigma(rho=8), @Meta.Sigma(rho=10), @Meta.Sigma(rho=11),
-    @Meta.Sigma(rho=12), @Meta.Sigma(rho=13), @Meta.Sigma(rho=16), @Meta.Sigma(rho=17)
+    @Meta.Sigma(rho=12), @Meta.Sigma(rho=13), @Meta.Sigma(rho=16)
   },
   exprs={@Meta.Expr()}
 )
@@ -307,82 +299,38 @@ final public class HoverLSP  {
 
 final public static class THoverLSP  {
   final public static org.eclipse.lsp4j.Hover fromHover(final Hover.THover arg$1) {
-    final String/*<Character>*/ content$18108 = arg$1.mem$content.call();
-    final Range.TRange range$18107 = arg$1.mem$range.call();
+    final String/*<Character>*/ content$18105 = arg$1.mem$content.call();
+    final Range.TRange range$18104 = arg$1.mem$range.call();
     return new org.eclipse.lsp4j.Hover(
           new org.eclipse.lsp4j.MarkupContent(
-            org.eclipse.lsp4j.MarkupKind.MARKDOWN, Hover.IShow_FregeCodeBlock.show(content$18108)
+            org.eclipse.lsp4j.MarkupKind.MARKDOWN, Hover.IShow_FregeCodeBlock.show(content$18105)
           ),
-          RangeLSP4J.TRangeLSP.fromRange(range$18107)
+          RangeLSP4J.TRangeLSP.fromRange(range$18104)
         );
   }
 }
 final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWorld, Short>>shared(
       (Lazy<Func.U<RealWorld, Short>>)(() -> {
-            return Prelude.<String/*<Character>*/>println(PreludeText.IShow_String.it, "hello");
+            return Prelude.<String/*<Character>*/>println(PreludeText.IShow_String.it, "hello HoverLSP");
           })
     );
-final public static Func.U<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>> getTypeSignatureOnHoverLSP(
-  final Func.U<RealWorld, Global.TGlobal> arg$1, final Lazy<org.eclipse.lsp4j.Position> arg$2
+final public static PreludeBase.TMaybe<org.eclipse.lsp4j.Hover> getTypeSignatureOnHoverLSP(
+  final Lazy<org.eclipse.lsp4j.Position> arg$1, final Lazy<Global.TGlobal> arg$2
 ) {
-  return (Func.U<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>)((final Lazy<RealWorld> arg$18231) -> {
-            final PreludeBase.TMaybe<Hover.THover> v2056$18179 = Hover.getTypeSignatureOnHover(
-                  arg$1,
-                  Thunk.<Position.TPosition>shared(
-                        (Lazy<Position.TPosition>)(() -> PositionLSP4J.TPositionLSP.toPosition(
-                                  arg$2
-                                ))
-                      )
-                ).apply(arg$18231).call();
-            final Func.U<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>> v2057$18180 =
-            PreludeMonad.IMonad_ST.<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>pure(
-                  Thunk.<PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>shared(
-                        (Lazy<PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>)(() -> Maybe.IFunctor_Maybe.<
-                              Hover.THover, org.eclipse.lsp4j.Hover
-                            >fmap(
-                                  (Func.U<Hover.THover, org.eclipse.lsp4j.Hover>)((final Lazy<Hover.THover> η$18233) -> Thunk.<
-                                        org.eclipse.lsp4j.Hover
-                                      >shared((Lazy<org.eclipse.lsp4j.Hover>)(() -> THoverLSP.fromHover(η$18233.call())))),
-                                  v2056$18179
-                                ))
-                      )
-                );
-            return Thunk.<PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>nested(
-                      (Lazy<Lazy<PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>>)(() -> v2057$18180
-                          .apply(arg$18231))
-                    );
-          });
-}
-final public static Func.U<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>> compileAndGetTypeSignatureOnHoverLSP(
-  final Lazy<String/*<Character>*/> arg$1, final Lazy<org.eclipse.lsp4j.Position> arg$2
-) {
-  return (Func.U<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>)((final Lazy<RealWorld> arg$18235) -> {
-            final PreludeBase.TMaybe<Hover.THover> v2056$18208 = Hover.compileAndGetTypeSignatureOnHover(
-                  arg$1,
-                  Thunk.<Position.TPosition>shared(
-                        (Lazy<Position.TPosition>)(() -> PositionLSP4J.TPositionLSP.toPosition(
-                                  arg$2
-                                ))
-                      )
-                ).apply(arg$18235).call();
-            final Func.U<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>> v2057$18209 =
-            PreludeMonad.IMonad_ST.<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>pure(
-                  Thunk.<PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>shared(
-                        (Lazy<PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>)(() -> Maybe.IFunctor_Maybe.<
-                              Hover.THover, org.eclipse.lsp4j.Hover
-                            >fmap(
-                                  (Func.U<Hover.THover, org.eclipse.lsp4j.Hover>)((final Lazy<Hover.THover> η$18237) -> Thunk.<
-                                        org.eclipse.lsp4j.Hover
-                                      >shared((Lazy<org.eclipse.lsp4j.Hover>)(() -> THoverLSP.fromHover(η$18237.call())))),
-                                  v2056$18208
-                                ))
-                      )
-                );
-            return Thunk.<PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>nested(
-                      (Lazy<Lazy<PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>>)(() -> v2057$18209
-                          .apply(arg$18235))
-                    );
-          });
+  final PreludeBase.TMaybe<Hover.THover> $18156 = Hover.getTypeSignatureOnHover(
+        Thunk.<Position.TPosition>shared((Lazy<Position.TPosition>)(() -> PositionLSP4J.TPositionLSP.toPosition(arg$1))), arg$2
+      );
+  final PreludeBase.TMaybe.DJust<Hover.THover> $18157 = $18156.asJust();
+  if ($18157 != null) {
+    return Maybe.IApplicative_Maybe.<org.eclipse.lsp4j.Hover>pure(
+              Thunk.<org.eclipse.lsp4j.Hover>shared(
+                    (Lazy<org.eclipse.lsp4j.Hover>)(() -> THoverLSP.fromHover($18157.mem1.call()))
+                  )
+            );
+  }
+  final PreludeBase.TMaybe.DNothing<Hover.THover> $18158 = $18156.asNothing();
+  assert $18158 != null;
+  return PreludeBase.TMaybe.DNothing.<org.eclipse.lsp4j.Hover>mk();
 }
 
   public static void main(final java.lang.String[] argv) {

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/HoverLSP.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/HoverLSP.java
@@ -156,26 +156,27 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/HoverLSP.fr",
-  time=1658516066746L, jmajor=11, jminor=-1,
+  time=1658602830858L, jmajor=11, jminor=-1,
   imps={
-    "ch.fhnw.thga.fregelanguageserver.hover.Hover", "ch.fhnw.thga.fregelanguageserver.lsp4j.PositionLSP4J",
-    "frege.Prelude", "frege.prelude.PreludeArrays", "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal",
-    "frege.prelude.PreludeIO", "frege.prelude.PreludeList", "frege.prelude.PreludeMonad", "frege.prelude.PreludeText",
-    "ch.fhnw.thga.fregelanguageserver.lsp4j.RangeLSP4J", "frege.java.util.Regex"
+    "frege.compiler.types.Global", "ch.fhnw.thga.fregelanguageserver.hover.Hover",
+    "ch.fhnw.thga.fregelanguageserver.lsp4j.PositionLSP4J", "frege.Prelude", "frege.prelude.PreludeArrays",
+    "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal", "frege.prelude.PreludeIO", "frege.prelude.PreludeList",
+    "frege.prelude.PreludeMonad", "frege.prelude.PreludeText", "ch.fhnw.thga.fregelanguageserver.lsp4j.RangeLSP4J",
+    "frege.java.util.Regex", "frege.control.monad.State"
   },
   nmss={
-    "Hover", "PositionLSP4J", "Prelude", "PreludeArrays", "PreludeBase", "PreludeDecimal", "PreludeIO",
-    "PreludeList", "PreludeMonad", "PreludeText", "RangeLSP4J", "Regexp"
+    "Global", "Hover", "PositionLSP4J", "Prelude", "PreludeArrays", "PreludeBase", "PreludeDecimal",
+    "PreludeIO", "PreludeList", "PreludeMonad", "PreludeText", "RangeLSP4J", "Regexp", "State"
   },
   symas={}, symcs={}, symis={},
   symts={
     @Meta.SymT(
-      offset=305,
+      offset=407,
       name=@Meta.QName(kind=0, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="MarkupContentLSP"), typ=0,
       kind=4, cons={}, lnks={},
       funs={
         @Meta.SymV(
-          offset=390,
+          offset=492,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="MarkupContentLSP", member="new"
           ),
@@ -185,19 +186,19 @@ import frege.test.QuickCheckText;
       pur=true, nativ="org.eclipse.lsp4j.MarkupContent"
     ),
     @Meta.SymT(
-      offset=440,
+      offset=542,
       name=@Meta.QName(kind=0, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="MarkupKindLSP"), typ=3,
       kind=4, cons={}, lnks={},
       funs={
         @Meta.SymV(
-          offset=586,
+          offset=688,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="MarkupKindLSP", member="markdown"
           ),
           stri="s", sig=1, nativ="org.eclipse.lsp4j.MarkupKind.MARKDOWN", depth=0, rkind=9
         ),
         @Meta.SymV(
-          offset=514,
+          offset=616,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="MarkupKindLSP", member="plaintext"
           ),
@@ -207,18 +208,18 @@ import frege.test.QuickCheckText;
       pur=true, nativ="org.eclipse.lsp4j.MarkupKind"
     ),
     @Meta.SymT(
-      offset=653, name=@Meta.QName(kind=0, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="HoverLSP"),
+      offset=755, name=@Meta.QName(kind=0, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="HoverLSP"),
       typ=4, kind=4, cons={}, lnks={},
       funs={
         @Meta.SymV(
-          offset=775,
+          offset=877,
           name=@Meta.QName(
-            kind=2, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="HoverLSP", member="hoverToHoverLSP"
+            kind=2, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="HoverLSP", member="fromHover"
           ),
           stri="s(s(ss))", sig=6, depth=1, rkind=13
         ),
         @Meta.SymV(
-          offset=722,
+          offset=824,
           name=@Meta.QName(
             kind=2, pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="HoverLSP", member="new"
           ),
@@ -230,15 +231,20 @@ import frege.test.QuickCheckText;
   },
   symvs={
     @Meta.SymV(
-      offset=1275, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="main"), stri="u",
+      offset=1601, name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="main"), stri="u",
       sig=9, depth=0, rkind=8
     ),
     @Meta.SymV(
-      offset=994,
+      offset=1084,
+      name=@Meta.QName(pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="getTypeSignatureOnHoverLSP"),
+      stri="s(su)", sig=12, depth=2, rkind=13
+    ),
+    @Meta.SymV(
+      offset=1326,
       name=@Meta.QName(
         pack="ch.fhnw.thga.fregelanguageserver.hover.HoverLSP", base="compileAndGetTypeSignatureOnHoverLSP"
       ),
-      stri="s(uu)", sig=11, depth=2, rkind=13
+      stri="s(uu)", sig=13, depth=2, rkind=13
     )
   },
   symls={},
@@ -270,25 +276,27 @@ import frege.test.QuickCheckText;
     @Meta.Tau(kind=0, suba=9, subb=10),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.prelude.PreludeBase", base="()")}),
     @Meta.Tau(kind=0, suba=11, subb=12),
+    @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.compiler.types.Global", base="Global")}),
+    @Meta.Tau(kind=0, suba=11, subb=14),
     @Meta.Tau(
       kind=2, suba=0,
       tcon={@Meta.QName(kind=0, pack="ch.fhnw.thga.fregelanguageserver.lsp4j.PositionLSP4J", base="PositionLSP")}
     ),
     @Meta.Tau(kind=2, suba=0, tcon={@Meta.QName(kind=0, pack="frege.prelude.PreludeBase", base="Maybe")}),
-    @Meta.Tau(kind=0, suba=15, subb=6), @Meta.Tau(kind=0, suba=11, subb=16)
+    @Meta.Tau(kind=0, suba=17, subb=6), @Meta.Tau(kind=0, suba=11, subb=18)
   },
   rhos={
     @Meta.Rho(rhofun=false, rhotau=0), @Meta.Rho(rhofun=false, rhotau=3), @Meta.Rho(sigma=1, rhotau=0),
     @Meta.Rho(sigma=1, rhotau=2), @Meta.Rho(rhofun=false, rhotau=5), @Meta.Rho(rhofun=false, rhotau=6),
     @Meta.Rho(rhofun=false, rhotau=7), @Meta.Rho(sigma=5, rhotau=5), @Meta.Rho(rhofun=false, rhotau=8),
     @Meta.Rho(sigma=7, rhotau=5), @Meta.Rho(sigma=0, rhotau=9), @Meta.Rho(rhofun=false, rhotau=13),
-    @Meta.Rho(rhofun=false, rhotau=14), @Meta.Rho(rhofun=false, rhotau=17), @Meta.Rho(sigma=10, rhotau=13),
-    @Meta.Rho(sigma=1, rhotau=14)
+    @Meta.Rho(rhofun=false, rhotau=15), @Meta.Rho(rhofun=false, rhotau=16), @Meta.Rho(rhofun=false, rhotau=19),
+    @Meta.Rho(sigma=11, rhotau=14), @Meta.Rho(sigma=10, rhotau=15), @Meta.Rho(sigma=1, rhotau=15)
   },
   sigmas={
     @Meta.Sigma(rho=0), @Meta.Sigma(rho=1), @Meta.Sigma(rho=3), @Meta.Sigma(rho=4), @Meta.Sigma(rho=5),
     @Meta.Sigma(rho=6), @Meta.Sigma(rho=7), @Meta.Sigma(rho=8), @Meta.Sigma(rho=10), @Meta.Sigma(rho=11),
-    @Meta.Sigma(rho=12), @Meta.Sigma(rho=15)
+    @Meta.Sigma(rho=12), @Meta.Sigma(rho=13), @Meta.Sigma(rho=16), @Meta.Sigma(rho=17)
   },
   exprs={@Meta.Expr()}
 )
@@ -298,14 +306,14 @@ final public class HoverLSP  {
 
 
 final public static class THoverLSP  {
-  final public static org.eclipse.lsp4j.Hover hoverToHoverLSP(final Hover.THover arg$1) {
-    final String/*<Character>*/ content$18102 = arg$1.mem$content.call();
-    final Range.TRange range$18101 = arg$1.mem$range.call();
+  final public static org.eclipse.lsp4j.Hover fromHover(final Hover.THover arg$1) {
+    final String/*<Character>*/ content$18108 = arg$1.mem$content.call();
+    final Range.TRange range$18107 = arg$1.mem$range.call();
     return new org.eclipse.lsp4j.Hover(
           new org.eclipse.lsp4j.MarkupContent(
-            org.eclipse.lsp4j.MarkupKind.MARKDOWN, Hover.IShow_FregeCodeBlock.show(content$18102)
+            org.eclipse.lsp4j.MarkupKind.MARKDOWN, Hover.IShow_FregeCodeBlock.show(content$18108)
           ),
-          RangeLSP4J.TRangeLSP.fromRange(range$18101)
+          RangeLSP4J.TRangeLSP.fromRange(range$18107)
         );
   }
 }
@@ -314,38 +322,65 @@ final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWor
             return Prelude.<String/*<Character>*/>println(PreludeText.IShow_String.it, "hello");
           })
     );
-final public static Func.U<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>> compileAndGetTypeSignatureOnHoverLSP(
-  final Lazy<String/*<Character>*/> arg$1, final Lazy<org.eclipse.lsp4j.Position> arg$2
+final public static Func.U<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>> getTypeSignatureOnHoverLSP(
+  final Func.U<RealWorld, Global.TGlobal> arg$1, final Lazy<org.eclipse.lsp4j.Position> arg$2
 ) {
-  return (Func.U<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>)((final Lazy<RealWorld> arg$18170) -> {
-            final PreludeBase.TMaybe<Hover.THover> v2056$18147 = Hover.compileAndGetTypeSignatureOnHover(
+  return (Func.U<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>)((final Lazy<RealWorld> arg$18231) -> {
+            final PreludeBase.TMaybe<Hover.THover> v2056$18179 = Hover.getTypeSignatureOnHover(
                   arg$1,
                   Thunk.<Position.TPosition>shared(
                         (Lazy<Position.TPosition>)(() -> PositionLSP4J.TPositionLSP.toPosition(
                                   arg$2
                                 ))
                       )
-                ).apply(arg$18170).call();
-            final Func.U<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>> v2057$18148 =
+                ).apply(arg$18231).call();
+            final Func.U<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>> v2057$18180 =
             PreludeMonad.IMonad_ST.<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>pure(
                   Thunk.<PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>shared(
                         (Lazy<PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>)(() -> Maybe.IFunctor_Maybe.<
                               Hover.THover, org.eclipse.lsp4j.Hover
                             >fmap(
-                                  (Func.U<Hover.THover, org.eclipse.lsp4j.Hover>)((final Lazy<Hover.THover> η$18172) -> Thunk.<
+                                  (Func.U<Hover.THover, org.eclipse.lsp4j.Hover>)((final Lazy<Hover.THover> η$18233) -> Thunk.<
                                         org.eclipse.lsp4j.Hover
-                                      >shared(
-                                            (Lazy<org.eclipse.lsp4j.Hover>)(() -> THoverLSP.hoverToHoverLSP(
-                                                      η$18172.call()
-                                                    ))
-                                          )),
-                                  v2056$18147
+                                      >shared((Lazy<org.eclipse.lsp4j.Hover>)(() -> THoverLSP.fromHover(η$18233.call())))),
+                                  v2056$18179
                                 ))
                       )
                 );
             return Thunk.<PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>nested(
-                      (Lazy<Lazy<PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>>)(() -> v2057$18148
-                          .apply(arg$18170))
+                      (Lazy<Lazy<PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>>)(() -> v2057$18180
+                          .apply(arg$18231))
+                    );
+          });
+}
+final public static Func.U<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>> compileAndGetTypeSignatureOnHoverLSP(
+  final Lazy<String/*<Character>*/> arg$1, final Lazy<org.eclipse.lsp4j.Position> arg$2
+) {
+  return (Func.U<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>)((final Lazy<RealWorld> arg$18235) -> {
+            final PreludeBase.TMaybe<Hover.THover> v2056$18208 = Hover.compileAndGetTypeSignatureOnHover(
+                  arg$1,
+                  Thunk.<Position.TPosition>shared(
+                        (Lazy<Position.TPosition>)(() -> PositionLSP4J.TPositionLSP.toPosition(
+                                  arg$2
+                                ))
+                      )
+                ).apply(arg$18235).call();
+            final Func.U<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>> v2057$18209 =
+            PreludeMonad.IMonad_ST.<RealWorld, PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>pure(
+                  Thunk.<PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>shared(
+                        (Lazy<PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>)(() -> Maybe.IFunctor_Maybe.<
+                              Hover.THover, org.eclipse.lsp4j.Hover
+                            >fmap(
+                                  (Func.U<Hover.THover, org.eclipse.lsp4j.Hover>)((final Lazy<Hover.THover> η$18237) -> Thunk.<
+                                        org.eclipse.lsp4j.Hover
+                                      >shared((Lazy<org.eclipse.lsp4j.Hover>)(() -> THoverLSP.fromHover(η$18237.call())))),
+                                  v2056$18208
+                                ))
+                      )
+                );
+            return Thunk.<PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>nested(
+                      (Lazy<Lazy<PreludeBase.TMaybe<org.eclipse.lsp4j.Hover>>>)(() -> v2057$18209
+                          .apply(arg$18235))
                     );
           });
 }

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/HoverService.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/HoverService.java
@@ -8,14 +8,21 @@ import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
 
+import frege.compiler.types.Global.TGlobal;
 import frege.prelude.Maybe;
 import frege.prelude.PreludeBase.TMaybe;
 import frege.run8.Thunk;
+import frege.run8.Func.U;
+import frege.runtime.Phantom.RealWorld;
 
 public class HoverService
 {
 
-    public static CompletableFuture<Hover> hover(HoverParams params, String fregeCode)
+    public static CompletableFuture<Hover> hover
+        (
+            HoverParams params, 
+            U<RealWorld, TGlobal> global
+        )
     {
         return CompletableFutures.computeAsync(cancel ->
         {
@@ -25,8 +32,8 @@ public class HoverService
             }
             
             TMaybe<Hover> hover = performUnsafe(
-                HoverLSP.compileAndGetTypeSignatureOnHoverLSP(
-                    Thunk.lazy(fregeCode), 
+                HoverLSP.getTypeSignatureOnHoverLSP(
+                    global, 
                     Thunk.lazy(params.getPosition())).call()).call();
             if (Maybe.isNothing(hover)) return null;
             return hover.asJust().mem1.call();

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/HoverService.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/HoverService.java
@@ -1,7 +1,5 @@
 package ch.fhnw.thga.fregelanguageserver.hover;
 
-import static frege.prelude.PreludeBase.TST.performUnsafe;
-
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.lsp4j.Hover;
@@ -12,8 +10,6 @@ import frege.compiler.types.Global.TGlobal;
 import frege.prelude.Maybe;
 import frege.prelude.PreludeBase.TMaybe;
 import frege.run8.Thunk;
-import frege.run8.Func.U;
-import frege.runtime.Phantom.RealWorld;
 
 public class HoverService
 {
@@ -21,7 +17,7 @@ public class HoverService
     public static CompletableFuture<Hover> hover
         (
             HoverParams params, 
-            U<RealWorld, TGlobal> global
+            TGlobal global
         )
     {
         return CompletableFutures.computeAsync(cancel ->
@@ -31,10 +27,12 @@ public class HoverService
                 return null;
             }
             
-            TMaybe<Hover> hover = performUnsafe(
-                HoverLSP.getTypeSignatureOnHoverLSP(
-                    global, 
-                    Thunk.lazy(params.getPosition())).call()).call();
+            TMaybe<Hover> hover = HoverLSP.getTypeSignatureOnHoverLSP
+            ( 
+                Thunk.lazy(params.getPosition()),
+                global
+            ).call();
+
             if (Maybe.isNothing(hover)) return null;
             return hover.asJust().mem1.call();
         });

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/lsp4j/PositionLSP4J.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/lsp4j/PositionLSP4J.java
@@ -36,7 +36,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/lsp4j/PositionLSP4J.fr",
-  time=1658602828607L, jmajor=11, jminor=-1,
+  time=1658948162082L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.types.Position", "frege.Prelude", "frege.prelude.PreludeArrays",
     "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal", "frege.prelude.PreludeIO", "frege.prelude.PreludeList",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/lsp4j/PositionLSP4J.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/lsp4j/PositionLSP4J.java
@@ -36,7 +36,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/lsp4j/PositionLSP4J.fr",
-  time=1658516064617L, jmajor=11, jminor=-1,
+  time=1658602828607L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.types.Position", "frege.Prelude", "frege.prelude.PreludeArrays",
     "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal", "frege.prelude.PreludeIO", "frege.prelude.PreludeList",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/lsp4j/RangeLSP4J.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/lsp4j/RangeLSP4J.java
@@ -40,7 +40,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/lsp4j/RangeLSP4J.fr",
-  time=1658516064898L, jmajor=11, jminor=-1,
+  time=1658602829008L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.lsp4j.PositionLSP4J", "frege.Prelude", "frege.prelude.PreludeArrays",
     "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal", "frege.prelude.PreludeIO", "frege.prelude.PreludeList",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/lsp4j/RangeLSP4J.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/lsp4j/RangeLSP4J.java
@@ -40,7 +40,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/lsp4j/RangeLSP4J.fr",
-  time=1658602829008L, jmajor=11, jminor=-1,
+  time=1658948162388L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.lsp4j.PositionLSP4J", "frege.Prelude", "frege.prelude.PreludeArrays",
     "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal", "frege.prelude.PreludeIO", "frege.prelude.PreludeList",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/types/Position.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/types/Position.java
@@ -34,7 +34,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/types/Position.fr",
-  time=1658602827607L, jmajor=11, jminor=-1,
+  time=1658948161226L, jmajor=11, jminor=-1,
   imps={
     "frege.Prelude", "frege.prelude.PreludeArrays", "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal",
     "frege.prelude.PreludeIO", "frege.prelude.PreludeList", "frege.prelude.PreludeMonad", "frege.prelude.PreludeText",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/types/Position.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/types/Position.java
@@ -34,7 +34,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/types/Position.fr",
-  time=1658516063783L, jmajor=11, jminor=-1,
+  time=1658602827607L, jmajor=11, jminor=-1,
   imps={
     "frege.Prelude", "frege.prelude.PreludeArrays", "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal",
     "frege.prelude.PreludeIO", "frege.prelude.PreludeList", "frege.prelude.PreludeMonad", "frege.prelude.PreludeText",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/types/Range.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/types/Range.java
@@ -37,7 +37,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/types/Range.fr",
-  time=1658602828575L, jmajor=11, jminor=-1,
+  time=1658948162051L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.types.Position", "frege.Prelude", "frege.prelude.PreludeArrays",
     "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal", "frege.prelude.PreludeIO", "frege.prelude.PreludeList",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/types/Range.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/types/Range.java
@@ -37,7 +37,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/types/Range.fr",
-  time=1658516064580L, jmajor=11, jminor=-1,
+  time=1658602828575L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.types.Position", "frege.Prelude", "frege.prelude.PreludeArrays",
     "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal", "frege.prelude.PreludeIO", "frege.prelude.PreludeList",


### PR DESCRIPTION
Fixes #27.

Code changes should drive the compilation. Therefore, compilation is triggered in the didSave, didChange events and update the global. The language features then just get the information from the global. Besides, this makes the language features pure (no more IO dependency from compile).
