### PR TITLE
Support Multiple Open Frege Files

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version       = 3.2.1-alpha
+version       = 3.3.0-alpha
 gradleVersion = 7.4.2

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/FregeLanguageServer.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/FregeLanguageServer.java
@@ -1,7 +1,5 @@
 package ch.fhnw.thga.fregelanguageserver;
 
-import static frege.prelude.PreludeBase.TST.performUnsafe;
-
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.lsp4j.InitializeParams;
@@ -13,9 +11,6 @@ import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
-
-import ch.fhnw.thga.fregelanguageserver.compile.CompileGlobal;
-import ch.fhnw.thga.fregelanguageserver.compile.CompileOptions;
 
 public class FregeLanguageServer implements LanguageServer, LanguageClientAware 
 {
@@ -37,14 +32,6 @@ public class FregeLanguageServer implements LanguageServer, LanguageClientAware
 	@Override
 	public CompletableFuture<InitializeResult> initialize(InitializeParams params)
     {
-        textService.setGlobal
-        (
-            performUnsafe
-            (
-                CompileGlobal
-                .fromOptions(CompileOptions.standardCompileOptions.call()).call()
-            ).call()
-        );
 		final InitializeResult res = new InitializeResult(new ServerCapabilities());
 		res.getCapabilities().setTextDocumentSync(TextDocumentSyncKind.Full);
 		res.getCapabilities().setHoverProvider(true);

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.java
@@ -137,7 +137,7 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.fr",
-  time=1658948162853L, jmajor=11, jminor=-1,
+  time=1659200053045L, jmajor=11, jminor=-1,
   imps={
     "frege.compiler.Classes", "ch.fhnw.thga.fregelanguageserver.compile.CompileGlobal",
     "ch.fhnw.thga.fregelanguageserver.compile.CompileOptions", "frege.compiler.common.CompilerOptions",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileGlobal.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileGlobal.java
@@ -82,7 +82,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/compile/CompileGlobal.fr",
-  time=1658948162095L, jmajor=11, jminor=-1,
+  time=1659200052355L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.compile.CompileOptions", "frege.compiler.common.CompilerOptions",
     "frege.compiler.types.Global", "frege.Prelude", "frege.prelude.PreludeArrays", "frege.prelude.PreludeBase",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileOptions.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileOptions.java
@@ -78,7 +78,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/compile/CompileOptions.fr",
-  time=1658948161221L, jmajor=11, jminor=-1,
+  time=1659200051382L, jmajor=11, jminor=-1,
   imps={
     "frege.compiler.enums.Flags", "frege.compiler.types.Global", "frege.Prelude", "frege.prelude.PreludeArrays",
     "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal", "frege.prelude.PreludeIO", "frege.prelude.PreludeList",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.java
@@ -140,7 +140,7 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.fr",
-  time=1658948163560L, jmajor=11, jminor=-1,
+  time=1659200053722L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.compile.CompileExecutor",
     "ch.fhnw.thga.fregelanguageserver.compile.CompileGlobal", "frege.compiler.types.Global",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.java
@@ -143,7 +143,7 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.fr",
-  time=1658948164070L, jmajor=11, jminor=-1,
+  time=1659200054226L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", "frege.compiler.types.Global", "frege.Prelude",
     "frege.prelude.PreludeArrays", "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticService.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticService.java
@@ -26,8 +26,9 @@ public class DiagnosticService
     {
 		CompletableFuture.runAsync(() -> 
         {
+            List<Diagnostic> diagnostics = getCompilerDiagnostics(global);
             client.publishDiagnostics(new PublishDiagnosticsParams(
-                documentUri, getCompilerDiagnostics(global)));
+                documentUri, diagnostics));
         });
 	}
 

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/Hover.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/Hover.java
@@ -153,7 +153,7 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr",
-  time=1658948163634L, jmajor=11, jminor=-1,
+  time=1659200053754L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.compile.CompileExecutor",
     "ch.fhnw.thga.fregelanguageserver.compile.CompileGlobal", "frege.compiler.types.Global", "frege.data.List",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/HoverLSP.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/HoverLSP.java
@@ -156,7 +156,7 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/HoverLSP.fr",
-  time=1658948164148L, jmajor=11, jminor=-1,
+  time=1659200054265L, jmajor=11, jminor=-1,
   imps={
     "frege.compiler.types.Global", "ch.fhnw.thga.fregelanguageserver.hover.Hover",
     "ch.fhnw.thga.fregelanguageserver.lsp4j.PositionLSP4J", "frege.Prelude", "frege.prelude.PreludeArrays",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/lsp4j/PositionLSP4J.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/lsp4j/PositionLSP4J.java
@@ -36,7 +36,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/lsp4j/PositionLSP4J.fr",
-  time=1658948162082L, jmajor=11, jminor=-1,
+  time=1659200052339L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.types.Position", "frege.Prelude", "frege.prelude.PreludeArrays",
     "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal", "frege.prelude.PreludeIO", "frege.prelude.PreludeList",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/lsp4j/RangeLSP4J.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/lsp4j/RangeLSP4J.java
@@ -40,7 +40,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/lsp4j/RangeLSP4J.fr",
-  time=1658948162388L, jmajor=11, jminor=-1,
+  time=1659200052624L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.lsp4j.PositionLSP4J", "frege.Prelude", "frege.prelude.PreludeArrays",
     "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal", "frege.prelude.PreludeIO", "frege.prelude.PreludeList",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/types/Position.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/types/Position.java
@@ -34,7 +34,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/types/Position.fr",
-  time=1658948161226L, jmajor=11, jminor=-1,
+  time=1659200051387L, jmajor=11, jminor=-1,
   imps={
     "frege.Prelude", "frege.prelude.PreludeArrays", "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal",
     "frege.prelude.PreludeIO", "frege.prelude.PreludeList", "frege.prelude.PreludeMonad", "frege.prelude.PreludeText",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/types/Range.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/types/Range.java
@@ -37,7 +37,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/types/Range.fr",
-  time=1658948162051L, jmajor=11, jminor=-1,
+  time=1659200052366L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.types.Position", "frege.Prelude", "frege.prelude.PreludeArrays",
     "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal", "frege.prelude.PreludeIO", "frege.prelude.PreludeList",


### PR DESCRIPTION
Fixes #32.

Saves the state of all Frege files with a hash map mapping `fileUri -> Global`.