### PR TITLE
Partly Support Local Frege File Imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bin
 .vscode
 .idea
 frege-native-gen*
+.frege-ls

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version       = 3.3.0-alpha
+version       = 3.4.0-alpha
 gradleVersion = 7.4.2

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/compile/CompileExecutor.fr
@@ -20,6 +20,8 @@ import Compiler.passes.GlobalLam as GL()
 import Compiler.passes.Easy as EA()
 import Compiler.passes.Strict as SC()
 import Compiler.passes.Final as FI()
+import Compiler.passes.GenCode()
+import Compiler.GenMeta as GM()
 import Compiler.Classes()
 import Compiler.Typecheck as TC()
 import Compiler.grammar.Lexer as L()
@@ -29,6 +31,8 @@ import Compiler.common.Desugar
 import Compiler.types.Tokens
 import Compiler.enums.TokenID
 import Compiler.types.Packs
+import Compiler.Main(openFilePrinter, closePrinter, javac)
+import frege.Version(version)
 import Test.QuickCheck (Property, once, morallyDubiousIOProperty)
 
 instance Show Message where
@@ -51,8 +55,18 @@ passes =
         (liftStG EA.pass,               "simplify expressions"),            -- TRACE9
         (liftStG GL.pass,               "globalize anonymous lambdas"),     -- TRACE8
         (liftStG SC.pass,               "strictness analysis"),             -- TRACES
-        (liftStG FI.cleanSymtab,        "clean up")
+        (openPrinter,                   "open file"),
+        (GM.genmeta,                    "generate meta data"),              -- none
+        (GenCode.pass,                  "generate java code"),              -- TRACEG
+        (closePrinter,                  "close java file"),
+        (javac,                         "run java compiler"),
+        (liftStG FI.cleanSymtab,        "clean up"),
     ]
+
+openPrinter = do
+    openFilePrinter ".java"
+    GM.banner version
+    return ("file", 1)
 
 switchState :: Global -> StG Global
 switchState new = do

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/compile/CompileOptions.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/compile/CompileOptions.fr
@@ -10,8 +10,8 @@ standardCompileOptions :: Options
 standardCompileOptions = Options 
     { 
         source       = "-",
-        sourcePath   = [ getEnvDefault "." "FREGE_LS_SOURCE_DIR" ],
-        dir          = ".",
+        sourcePath   = [ getEnvDefault "./src/main/frege" "FREGE_LS_SOURCE_DIR" ],
+        dir          = "./.frege-ls/classes/frege",
         path         = [ getEnvDefault "" "FREGE_LS_EXTRA_CLASSPATH" ],
         prefix       = "",
         encoding     = Just "UTF-8",
@@ -26,6 +26,9 @@ standardCompileOptions = Options
                        HINTS,
                        VERBOSE,
                        IDEMODE,
-                       IDETOKENS
+                       IDETOKENS,
+                       WITHCP,
+                       RUNJAVAC,
+                       MAKE
                      ]
     }

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileGlobal.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileGlobal.java
@@ -82,7 +82,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/compile/CompileGlobal.fr",
-  time=1659200052355L, jmajor=11, jminor=-1,
+  time=1659433739745L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.compile.CompileOptions", "frege.compiler.common.CompilerOptions",
     "frege.compiler.types.Global", "frege.Prelude", "frege.prelude.PreludeArrays", "frege.prelude.PreludeBase",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileOptions.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/compile/CompileOptions.java
@@ -78,7 +78,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/compile/CompileOptions.fr",
-  time=1659200051382L, jmajor=11, jminor=-1,
+  time=1659433738980L, jmajor=11, jminor=-1,
   imps={
     "frege.compiler.enums.Flags", "frege.compiler.types.Global", "frege.Prelude", "frege.prelude.PreludeArrays",
     "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal", "frege.prelude.PreludeIO", "frege.prelude.PreludeList",
@@ -130,8 +130,8 @@ final public static Lazy<String/*<Character>*/> getEnvDefault(
 ) {
   return PreludeBase.<String/*<Character>*/, String/*<Character>*/>maybe(
             arg$1,
-            (Func.U<String/*<Character>*/, String/*<Character>*/>)((final Lazy<String/*<Character>*/> arg$12943) -> {
-                  return arg$12943;
+            (Func.U<String/*<Character>*/, String/*<Character>*/>)((final Lazy<String/*<Character>*/> arg$12949) -> {
+                  return arg$12949;
                 }),
             PreludeBase._toMaybe(System.getenv(arg$2))
           );
@@ -143,7 +143,7 @@ final public static Lazy<Global.TOptions> standardCompileOptions = Thunk.<Global
                       PreludeBase.TList.DCons.<String/*<Character>*/>mk(
                             Thunk.<String/*<Character>*/>nested(
                                   (Lazy<Lazy<String/*<Character>*/>>)(() -> CompileOptions.getEnvDefault(
-                                            Thunk.<String/*<Character>*/>lazy("."), "FREGE_LS_SOURCE_DIR"
+                                            Thunk.<String/*<Character>*/>lazy("./src/main/frege"), "FREGE_LS_SOURCE_DIR"
                                           ))
                                 ),
                             PreludeBase.TList.DList.<String/*<Character>*/>mk()
@@ -160,14 +160,26 @@ final public static Lazy<Global.TOptions> standardCompileOptions = Thunk.<Global
                                                     Thunk.<Short>lazy(Flags.TFlag.IDEMODE),
                                                     PreludeBase.TList.DCons.<Short>mk(
                                                           Thunk.<Short>lazy(Flags.TFlag.IDETOKENS),
-                                                          PreludeBase.TList.DList.<Short>mk()
+                                                          PreludeBase.TList.DCons.<Short>mk(
+                                                                Thunk.<Short>lazy(Flags.TFlag.WITHCP),
+                                                                PreludeBase.TList.DCons.<
+                                                                  Short
+                                                                >mk(
+                                                                      Thunk.<Short>lazy(
+                                                                            Flags.TFlag.RUNJAVAC
+                                                                          ),
+                                                                      PreludeBase.TList.DList.<
+                                                                        Short
+                                                                      >mk()
+                                                                    )
+                                                              )
                                                         )
                                                   )
                                             )
                                       )
                                 )
                           ),
-                      ".",
+                      "./.frege-ls/classes/frege",
                       PreludeBase.TList.DCons.<String/*<Character>*/>mk(
                             Thunk.<String/*<Character>*/>nested(
                                   (Lazy<Lazy<String/*<Character>*/>>)(() -> CompileOptions.getEnvDefault(

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.java
@@ -25,8 +25,10 @@ import frege.Prelude;
 import frege.Version;
 import frege.compiler.Classes;
 import frege.compiler.Classtools;
+import frege.compiler.GenMeta;
 import frege.compiler.Javatypes;
 import frege.compiler.Kinds;
+import frege.compiler.Main;
 import frege.compiler.Typecheck;
 import frege.compiler.Utilities;
 import frege.compiler.classes.Nice;
@@ -55,8 +57,16 @@ import frege.compiler.enums.RFlag;
 import frege.compiler.enums.SymState;
 import frege.compiler.enums.TokenID;
 import frege.compiler.enums.Visibility;
+import frege.compiler.gen.java.Bindings;
 import frege.compiler.gen.java.Common;
+import frege.compiler.gen.java.Constants;
+import frege.compiler.gen.java.DataCode;
+import frege.compiler.gen.java.InstanceCode;
+import frege.compiler.gen.java.Instantiation;
+import frege.compiler.gen.java.Match;
+import frege.compiler.gen.java.MethodCall;
 import frege.compiler.gen.java.PrettyJava;
+import frege.compiler.gen.java.VarCode;
 import frege.compiler.grammar.Frege;
 import frege.compiler.grammar.Lexer;
 import frege.compiler.instances.NiceExprS;
@@ -67,6 +77,7 @@ import frege.compiler.passes.Enter;
 import frege.compiler.passes.Fields;
 import frege.compiler.passes.Final;
 import frege.compiler.passes.Fix;
+import frege.compiler.passes.GenCode;
 import frege.compiler.passes.GlobalLam;
 import frege.compiler.passes.Imp;
 import frege.compiler.passes.Instances;
@@ -95,6 +106,7 @@ import frege.compiler.types.Symbols;
 import frege.compiler.types.Targets;
 import frege.compiler.types.Tokens;
 import frege.control.Category;
+import frege.control.Concurrent;
 import frege.control.Semigroupoid;
 import frege.control.monad.State;
 import frege.control.monad.trans.MonadIO;
@@ -140,7 +152,7 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.fr",
-  time=1659200053722L, jmajor=11, jminor=-1,
+  time=1659433741211L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.compile.CompileExecutor",
     "ch.fhnw.thga.fregelanguageserver.compile.CompileGlobal", "frege.compiler.types.Global",
@@ -946,14 +958,14 @@ final public static class IShow_Diagnostic implements PreludeText.CShow<TDiagnos
     return IShow_Diagnostic.showChars(arg$1.call());
   }
   final public static String/*<Character>*/ showsub(final TDiagnostic arg$1) {
-    final String/*<Character>*/ a4$17477 = arg$1.mem$message.call();
-    final String/*<Character>*/ a3$17476 = arg$1.mem$source.call();
-    final short a2$17475 = (short)arg$1.mem$severity.call();
-    final Range.TRange a1$17474 = arg$1.mem$range.call();
-    return ("(" + (((((((("Diagnostic" + " ") + Range.IShow_Range.showsub(a1$17474)) + " ") + IShow_DiagnosticSeverity.showsub(
-              a2$17475
-            )) + " ") + PreludeText.IShow_String.showsub(a3$17476)) + " ") + PreludeText.IShow_String.showsub(
-              a4$17477
+    final String/*<Character>*/ a4$17846 = arg$1.mem$message.call();
+    final String/*<Character>*/ a3$17845 = arg$1.mem$source.call();
+    final short a2$17844 = (short)arg$1.mem$severity.call();
+    final Range.TRange a1$17843 = arg$1.mem$range.call();
+    return ("(" + (((((((("Diagnostic" + " ") + Range.IShow_Range.showsub(a1$17843)) + " ") + IShow_DiagnosticSeverity.showsub(
+              a2$17844
+            )) + " ") + PreludeText.IShow_String.showsub(a3$17845)) + " ") + PreludeText.IShow_String.showsub(
+              a4$17846
             ))) + ")";
   }
   final public static String/*<Character>*/ showList(
@@ -962,9 +974,9 @@ final public static class IShow_Diagnostic implements PreludeText.CShow<TDiagnos
     return "[" + (PreludeText.joined(
               Thunk.<String/*<Character>*/>lazy(", "),
               PreludeList.<String/*<Character>*/, TDiagnostic>map(
-                    (Func.U<TDiagnostic, String/*<Character>*/>)((final Lazy<TDiagnostic> η$18710) -> Thunk.<
+                    (Func.U<TDiagnostic, String/*<Character>*/>)((final Lazy<TDiagnostic> η$19079) -> Thunk.<
                           String/*<Character>*/
-                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_Diagnostic.show(η$18710.call())))),
+                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_Diagnostic.show(η$19079.call())))),
                     arg$1
                   )
             ).call() + ("]" + arg$2));
@@ -978,14 +990,14 @@ final public static class IShow_Diagnostic implements PreludeText.CShow<TDiagnos
     return IShow_Diagnostic.show(arg$1);
   }
   final public static String/*<Character>*/ show(final TDiagnostic arg$1) {
-    final String/*<Character>*/ a4$17472 = arg$1.mem$message.call();
-    final String/*<Character>*/ a3$17471 = arg$1.mem$source.call();
-    final short a2$17470 = (short)arg$1.mem$severity.call();
-    final Range.TRange a1$17469 = arg$1.mem$range.call();
-    return ((((((("Diagnostic" + " ") + Range.IShow_Range.showsub(a1$17469)) + " ") + IShow_DiagnosticSeverity.showsub(
-              a2$17470
-            )) + " ") + PreludeText.IShow_String.showsub(a3$17471)) + " ") + PreludeText.IShow_String.showsub(
-              a4$17472
+    final String/*<Character>*/ a4$17841 = arg$1.mem$message.call();
+    final String/*<Character>*/ a3$17840 = arg$1.mem$source.call();
+    final short a2$17839 = (short)arg$1.mem$severity.call();
+    final Range.TRange a1$17838 = arg$1.mem$range.call();
+    return ((((((("Diagnostic" + " ") + Range.IShow_Range.showsub(a1$17838)) + " ") + IShow_DiagnosticSeverity.showsub(
+              a2$17839
+            )) + " ") + PreludeText.IShow_String.showsub(a3$17840)) + " ") + PreludeText.IShow_String.showsub(
+              a4$17841
             );
   }
   final public static PreludeBase.TList<Character> showChars(final TDiagnostic arg$1) {
@@ -1034,9 +1046,9 @@ final public static class IShow_DiagnosticSeverity implements PreludeText.CShow<
     return "[" + (PreludeText.joined(
               Thunk.<String/*<Character>*/>lazy(", "),
               PreludeList.<String/*<Character>*/, Short>map(
-                    (Func.U<Short, String/*<Character>*/>)((final Lazy<Short> η$18724) -> Thunk.<
+                    (Func.U<Short, String/*<Character>*/>)((final Lazy<Short> η$19093) -> Thunk.<
                           String/*<Character>*/
-                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_DiagnosticSeverity.show((short)η$18724.call())))),
+                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_DiagnosticSeverity.show((short)η$19093.call())))),
                     arg$1
                   )
             ).call() + ("]" + arg$2));
@@ -1079,13 +1091,13 @@ final public static class IEq_Diagnostic implements PreludeBase.CEq<TDiagnostic>
     return IEq_Diagnostic.$eq$eq(arg$1.call(), arg$2.call());
   }
   final public static int hashCode(final TDiagnostic arg$1) {
-    final String/*<Character>*/ a4$17467 = arg$1.mem$message.call();
-    final String/*<Character>*/ a3$17466 = arg$1.mem$source.call();
-    final short a2$17465 = (short)arg$1.mem$severity.call();
-    final Range.TRange a1$17464 = arg$1.mem$range.call();
+    final String/*<Character>*/ a4$17836 = arg$1.mem$message.call();
+    final String/*<Character>*/ a3$17835 = arg$1.mem$source.call();
+    final short a2$17834 = (short)arg$1.mem$severity.call();
+    final Range.TRange a1$17833 = arg$1.mem$range.call();
     return (31 * ((31 * ((31 * ((31 * ((31 * 1) + RunTM.constructor(arg$1))) + Range.IEq_Range.hashCode(
-              a1$17464
-            ))) + IEq_DiagnosticSeverity.hashCode(a2$17465))) + a3$17466.hashCode())) + a4$17467
+              a1$17833
+            ))) + IEq_DiagnosticSeverity.hashCode(a2$17834))) + a3$17835.hashCode())) + a4$17836
         .hashCode();
   }
   final public static boolean $excl$eq(final TDiagnostic arg$1, final TDiagnostic arg$2) {
@@ -1097,17 +1109,17 @@ final public static class IEq_Diagnostic implements PreludeBase.CEq<TDiagnostic>
     }
   }
   final public static boolean $eq$eq(final TDiagnostic arg$1, final TDiagnostic arg$2) {
-    final String/*<Character>*/ µ$$17539 = arg$1.mem$message.call();
-    final String/*<Character>*/ µ$$17538 = arg$1.mem$source.call();
-    final short µ$$17537 = (short)arg$1.mem$severity.call();
-    final Range.TRange µ$$17536 = arg$1.mem$range.call();
-    final String/*<Character>*/ µ$$17543 = arg$2.mem$message.call();
-    final String/*<Character>*/ µ$$17542 = arg$2.mem$source.call();
-    final short µ$$17541 = (short)arg$2.mem$severity.call();
-    final Range.TRange µ$$17540 = arg$2.mem$range.call();
-    return Range.IEq_Range.$eq$eq(µ$$17536, µ$$17540) && (IEq_DiagnosticSeverity.$eq$eq(
-              µ$$17537, µ$$17541
-            ) && (µ$$17538.equals(µ$$17542) && µ$$17539.equals(µ$$17543)));
+    final String/*<Character>*/ µ$$17908 = arg$1.mem$message.call();
+    final String/*<Character>*/ µ$$17907 = arg$1.mem$source.call();
+    final short µ$$17906 = (short)arg$1.mem$severity.call();
+    final Range.TRange µ$$17905 = arg$1.mem$range.call();
+    final String/*<Character>*/ µ$$17912 = arg$2.mem$message.call();
+    final String/*<Character>*/ µ$$17911 = arg$2.mem$source.call();
+    final short µ$$17910 = (short)arg$2.mem$severity.call();
+    final Range.TRange µ$$17909 = arg$2.mem$range.call();
+    return Range.IEq_Range.$eq$eq(µ$$17905, µ$$17909) && (IEq_DiagnosticSeverity.$eq$eq(
+              µ$$17906, µ$$17910
+            ) && (µ$$17907.equals(µ$$17911) && µ$$17908.equals(µ$$17912)));
   }
 }
 final public static class IEq_DiagnosticSeverity implements PreludeBase.CEq<Short> {
@@ -1197,19 +1209,19 @@ final public static class TDiagnostic implements frege.runtime.Value, Lazy<TDiag
     return TDiagnostic.mk(arg$1.mem$range, arg$2, arg$1.mem$source, arg$1.mem$message);
   }
   final public static String/*<Character>*/ source(final TDiagnostic arg$1) {
-    final String/*<Character>*/ a3$17394 = arg$1.mem$source.call();
-    return a3$17394;
+    final String/*<Character>*/ a3$17763 = arg$1.mem$source.call();
+    return a3$17763;
   }
   final public static TDiagnostic upd$message(final TDiagnostic arg$1, final Lazy<String/*<Character>*/> arg$2) {
     return TDiagnostic.mk(arg$1.mem$range, arg$1.mem$severity, arg$1.mem$source, arg$2);
   }
   final public static Range.TRange range(final TDiagnostic arg$1) {
-    final Range.TRange a1$17356 = arg$1.mem$range.call();
-    return a1$17356;
+    final Range.TRange a1$17725 = arg$1.mem$range.call();
+    return a1$17725;
   }
   final public static short severity(final TDiagnostic arg$1) {
-    final short a2$17375 = (short)arg$1.mem$severity.call();
-    return a2$17375;
+    final short a2$17744 = (short)arg$1.mem$severity.call();
+    return a2$17744;
   }
   final public static <α> boolean has$source(final Lazy<α> arg$1) {
     return true;
@@ -1257,8 +1269,8 @@ final public static class TDiagnostic implements frege.runtime.Value, Lazy<TDiag
     return true;
   }
   final public static String/*<Character>*/ message(final TDiagnostic arg$1) {
-    final String/*<Character>*/ a4$17341 = arg$1.mem$message.call();
-    return a4$17341;
+    final String/*<Character>*/ a4$17710 = arg$1.mem$message.call();
+    return a4$17710;
   }
 }
 final public static class TDiagnosticSeverity  {
@@ -1268,40 +1280,40 @@ final public static class TDiagnosticSeverity  {
   final public static short INFORMATION = 2;
 }
 final public static Range.TRange tokensToRange(final PreludeBase.TList<Tokens.TToken> arg$1) {
-  final PreludeBase.TList.DList<Tokens.TToken> $18751 = arg$1.asList();
-  if ($18751 != null) {
+  final PreludeBase.TList.DList<Tokens.TToken> $19120 = arg$1.asList();
+  if ($19120 != null) {
     return Range.TRange.mk(
               Position.TPosition.mk(Thunk.<Integer>lazy(1), Thunk.<Integer>lazy(0)),
               Position.TPosition.mk(Thunk.<Integer>lazy(2), Thunk.<Integer>lazy(0))
             );
   }
-  final PreludeBase.TList.DCons<Tokens.TToken> $18752 = arg$1.asCons();
-  if ($18752 != null) {
-    final PreludeBase.TList<Tokens.TToken> $18753 = $18752.mem2.call();
-    final PreludeBase.TList.DList<Tokens.TToken> $18754 = $18753.asList();
-    if ($18754 != null) {
-      final Tokens.TToken tk$17410 = $18752.mem1.call();
-      return Range.tokenToRange(tk$17410);
+  final PreludeBase.TList.DCons<Tokens.TToken> $19121 = arg$1.asCons();
+  if ($19121 != null) {
+    final PreludeBase.TList<Tokens.TToken> $19122 = $19121.mem2.call();
+    final PreludeBase.TList.DList<Tokens.TToken> $19123 = $19122.asList();
+    if ($19123 != null) {
+      final Tokens.TToken tk$17779 = $19121.mem1.call();
+      return Range.tokenToRange(tk$17779);
     }
   }
-  final Lazy<Tokens.TToken> endToken$17413 = Thunk.<Tokens.TToken>shared(
+  final Lazy<Tokens.TToken> endToken$17782 = Thunk.<Tokens.TToken>shared(
         (Lazy<Tokens.TToken>)(() -> PreludeList.<Tokens.TToken>last(arg$1))
       );
-  final Lazy<Tokens.TToken> startToken$17412 = Thunk.<Tokens.TToken>shared(
+  final Lazy<Tokens.TToken> startToken$17781 = Thunk.<Tokens.TToken>shared(
         (Lazy<Tokens.TToken>)(() -> PreludeList.IListView_$lbrack$rbrack.<Tokens.TToken>head(
                   arg$1
                 ))
       );
   return Range.TRange.mk(
             Position.TPosition.mk(
-                  Thunk.<Integer>lazy(Tokens.TToken.line(startToken$17412.call())),
-                  Thunk.<Integer>lazy(Tokens.TToken.col(startToken$17412.call()))
+                  Thunk.<Integer>lazy(Tokens.TToken.line(startToken$17781.call())),
+                  Thunk.<Integer>lazy(Tokens.TToken.col(startToken$17781.call()))
                 ),
             Position.TPosition.mk(
-                  Thunk.<Integer>lazy(Tokens.TToken.line(endToken$17413.call())),
+                  Thunk.<Integer>lazy(Tokens.TToken.line(endToken$17782.call())),
                   Thunk.<Integer>shared(
-                        (Lazy<Integer>)(() -> Tokens.TToken.col(endToken$17413.call()) + Tokens.TToken.value(
-                                  endToken$17413.call()
+                        (Lazy<Integer>)(() -> Tokens.TToken.col(endToken$17782.call()) + Tokens.TToken.value(
+                                  endToken$17782.call()
                                 ).length())
                       )
                 )
@@ -1310,65 +1322,65 @@ final public static Range.TRange tokensToRange(final PreludeBase.TList<Tokens.TT
 final public static PreludeBase.TList<Tokens.TToken> posToTokens(
   final PreludeBase.TList<Positions.TPosition> arg$1, final Lazy<Global.TGlobal> arg$2
 ) {
-  final PreludeBase.TList.DCons<Positions.TPosition> $18756 = arg$1.asCons();
-  if ($18756 != null) {
-    final Positions.TPosition µ$$17534 = $18756.mem1.call();
+  final PreludeBase.TList.DCons<Positions.TPosition> $19125 = arg$1.asCons();
+  if ($19125 != null) {
+    final Positions.TPosition µ$$17903 = $19125.mem1.call();
     return PreludeList.IListMonoid_$lbrack$rbrack.<Tokens.TToken>$plus$plus(
-              Global.tokens(µ$$17534, arg$2),
+              Global.tokens(µ$$17903, arg$2),
               Thunk.<PreludeBase.TList<Tokens.TToken>>shared(
                     (Lazy<PreludeBase.TList<Tokens.TToken>>)(() -> Diagnostic.posToTokens(
-                              $18756.mem2.call(), arg$2
+                              $19125.mem2.call(), arg$2
                             ))
                   )
             );
   }
-  final PreludeBase.TList.DList<Positions.TPosition> $18758 = arg$1.asList();
-  assert $18758 != null;
+  final PreludeBase.TList.DList<Positions.TPosition> $19127 = arg$1.asList();
+  assert $19127 != null;
   return PreludeBase.TList.DList.<Tokens.TToken>mk();
 }
 final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWorld, Short>>shared(
       (Lazy<Func.U<RealWorld, Short>>)(() -> {
-            return (Func.U<RealWorld, Short>)((final Lazy<RealWorld> arg$18759) -> {
-                      final Global.TGlobal v2056$18291 = CompileGlobal.standardCompileGlobal
-                      .call().apply(arg$18759).call();
-                      final Func.U<RealWorld, Global.TGlobal> v2053$18310 = CompileExecutor.compile(
+            return (Func.U<RealWorld, Short>)((final Lazy<RealWorld> arg$19128) -> {
+                      final Global.TGlobal v2056$18660 = CompileGlobal.standardCompileGlobal
+                      .call().apply(arg$19128).call();
+                      final Func.U<RealWorld, Global.TGlobal> v2053$18679 = CompileExecutor.compile(
                             Thunk.<String/*<Character>*/>lazy(
                                   "module FaultyFregeTest where\n\nsimplyString s = s\n\nerr1 = (simplyString 42) ++ \"test\""
                                 ),
-                            v2056$18291
+                            v2056$18660
                           );
-                      final Global.TGlobal v2056$18313 = v2053$18310.apply(arg$18759)
+                      final Global.TGlobal v2056$18682 = v2053$18679.apply(arg$19128)
                       .call();
-                      final Func.U<RealWorld, Short> v4793$18335 = Prelude.<String/*<Character>*/>println(
-                            PreludeText.IShow_String.it, Global.TSubSt.code(Global.TGlobal.sub(v2056$18313)).toString()
+                      final Func.U<RealWorld, Short> v4793$18704 = Prelude.<String/*<Character>*/>println(
+                            PreludeText.IShow_String.it, Global.TSubSt.code(Global.TGlobal.sub(v2056$18682)).toString()
                           );
-                      final short v4796$18337 = (short)v4793$18335.apply(arg$18759).call();
-                      final Func.U<RealWorld, Short> v4797$18338 = ((Func.U<RealWorld, Short>)((
-                        final Lazy<RealWorld> arg$18766
+                      final short v4796$18706 = (short)v4793$18704.apply(arg$19128).call();
+                      final Func.U<RealWorld, Short> v4797$18707 = ((Func.U<RealWorld, Short>)((
+                        final Lazy<RealWorld> arg$19135
                       ) -> {
-                            final short v4796$18368 = (short)Func.<RealWorld, Short>coerceU(
+                            final short v4796$18737 = (short)Func.<RealWorld, Short>coerceU(
                                   PreludeMonad.<Func.U<RealWorld, ?>, Global.TMessage, Short, PreludeBase.TList<?>>$for(
                                         PreludeMonad.IMonad_ST.<RealWorld>mk(),
                                         PreludeList.IListSource_$lbrack$rbrack.<PreludeBase.TList<?>>mk(),
                                         Thunk.<Kind.U<PreludeBase.TList<?>, Global.TMessage>>lazy(
                                               (Kind.U<PreludeBase.TList<?>, Global.TMessage>)Global.TSubSt.messages(
-                                                    Global.TGlobal.sub(v2056$18313)
+                                                    Global.TGlobal.sub(v2056$18682)
                                                   )
                                             ),
                                         (Func.U<Global.TMessage, Kind.U<Func.U<RealWorld, ?>, Short>>)((
-                                          final Lazy<Global.TMessage> η$18765
+                                          final Lazy<Global.TMessage> η$19134
                                         ) -> Thunk.<Kind.U<Func.U<RealWorld, ?>, Short>>shared(
                                                   (Lazy<Kind.U<Func.U<RealWorld, ?>, Short>>)(() -> (Kind.U<
                                                         Func.U<RealWorld, ?>, Short
                                                       >)Thunk.<Func.U<RealWorld, Short>>shared(
                                                             (Lazy<Func.U<RealWorld, Short>>)(() -> Prelude.<
                                                                   Global.TMessage
-                                                                >println(CompileExecutor.IShow_Message.it, η$18765.call()))
+                                                                >println(CompileExecutor.IShow_Message.it, η$19134.call()))
                                                           ).call())
                                                 ))
                                       )
-                                ).apply(arg$18766).call();
-                            final Func.U<RealWorld, Short> v4797$18369 = Thunk.<Func.U<RealWorld, Short>>shared(
+                                ).apply(arg$19135).call();
+                            final Func.U<RealWorld, Short> v4797$18738 = Thunk.<Func.U<RealWorld, Short>>shared(
                                   (Lazy<Func.U<RealWorld, Short>>)(() -> Func.<RealWorld, Short>coerceU(
                                             Thunk.<Kind.U<Func.U<RealWorld, ?>, Short>>shared(
                                                   (Lazy<Kind.U<Func.U<RealWorld, ?>, Short>>)(() -> PreludeMonad.<
@@ -1398,23 +1410,23 @@ final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWor
                                                                                               Global.TMessage,
                                                                                               Positions.TPosition
                                                                                             >)((
-                                                                                              final Lazy<Global.TMessage> η$18763
+                                                                                              final Lazy<Global.TMessage> η$19132
                                                                                             ) -> Global.TMessage.pos(
-                                                                                                      η$18763
+                                                                                                      η$19132
                                                                                                       .call()
                                                                                                     )),
                                                                                             Global.TSubSt.messages(
                                                                                                   Global.TGlobal.sub(
-                                                                                                        v2056$18313
+                                                                                                        v2056$18682
                                                                                                       )
                                                                                                 )
                                                                                           ),
-                                                                                      v2056$18313
+                                                                                      v2056$18682
                                                                                     ))
                                                                           ).call())
                                                                 ),
                                                             (Func.U<Tokens.TToken, Kind.U<Func.U<RealWorld, ?>, Short>>)((
-                                                              final Lazy<Tokens.TToken> η$18764
+                                                              final Lazy<Tokens.TToken> η$19133
                                                             ) -> Thunk.<Kind.U<Func.U<RealWorld, ?>, Short>>shared(
                                                                       (Lazy<Kind.U<Func.U<RealWorld, ?>, Short>>)(() -> (Kind.U<
                                                                             Func.U<RealWorld, ?>, Short
@@ -1425,7 +1437,7 @@ final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWor
                                                                                       Tokens.TToken
                                                                                     >println(
                                                                                           Tokens.IShow_Token.it,
-                                                                                          η$18764
+                                                                                          η$19133
                                                                                           .call()
                                                                                         ))
                                                                               ).call())
@@ -1434,9 +1446,9 @@ final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWor
                                                 ).call()
                                           ))
                                 ).call();
-                            return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$18369.apply(arg$18766)));
+                            return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$18738.apply(arg$19135)));
                           })).call();
-                      return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$18338.apply(arg$18759)));
+                      return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$18707.apply(arg$19128)));
                     });
           })
     );
@@ -1453,16 +1465,16 @@ final public static short fromCompilerSeverity(final short arg$1) {
 final public static State.TState<Global.TGlobal, Range.TRange> createRangeFromPos(final Positions.TPosition arg$1) {
   return State.TState.<Global.TGlobal, Range.TRange>mk(
             (Func.U<Global.TGlobal, PreludeBase.TTuple2<Range.TRange, Global.TGlobal>>)((
-              final Lazy<Global.TGlobal> arg$18772
+              final Lazy<Global.TGlobal> arg$19141
             ) -> {
-                  final State.TState<Global.TGlobal, Range.TRange> $18773 = State.IMonad_State.<
+                  final State.TState<Global.TGlobal, Range.TRange> $19142 = State.IMonad_State.<
                     Global.TGlobal, Range.TRange
-                  >pure(Diagnostic.tokensToRange(Global.tokens(arg$1, arg$18772)));
-                  final Func.U<Global.TGlobal, PreludeBase.TTuple2<Range.TRange, Global.TGlobal>> v7693$18642 =
-                  $18773.mem$fun;
+                  >pure(Diagnostic.tokensToRange(Global.tokens(arg$1, arg$19141)));
+                  final Func.U<Global.TGlobal, PreludeBase.TTuple2<Range.TRange, Global.TGlobal>> v7693$19011 =
+                  $19142.mem$fun;
                   return Thunk.<PreludeBase.TTuple2<Range.TRange, Global.TGlobal>>nested(
-                            (Lazy<Lazy<PreludeBase.TTuple2<Range.TRange, Global.TGlobal>>>)(() -> v7693$18642
-                                .apply(arg$18772))
+                            (Lazy<Lazy<PreludeBase.TTuple2<Range.TRange, Global.TGlobal>>>)(() -> v7693$19011
+                                .apply(arg$19141))
                           );
                 })
           );
@@ -1470,22 +1482,22 @@ final public static State.TState<Global.TGlobal, Range.TRange> createRangeFromPo
 final public static State.TState<Global.TGlobal, TDiagnostic> createDiagnosticFromMessage(
   final Global.TMessage arg$1
 ) {
-  final State.TState<Global.TGlobal, Range.TRange> $18775 = Diagnostic.createRangeFromPos(
+  final State.TState<Global.TGlobal, Range.TRange> $19144 = Diagnostic.createRangeFromPos(
         Global.TMessage.pos(arg$1)
       );
-  final Func.U<Global.TGlobal, PreludeBase.TTuple2<Range.TRange, Global.TGlobal>> v7688$18604 =
-  $18775.mem$fun;
+  final Func.U<Global.TGlobal, PreludeBase.TTuple2<Range.TRange, Global.TGlobal>> v7688$18973 =
+  $19144.mem$fun;
   return State.TState.<Global.TGlobal, TDiagnostic>mk(
             (Func.U<Global.TGlobal, PreludeBase.TTuple2<TDiagnostic, Global.TGlobal>>)((
-              final Lazy<Global.TGlobal> arg$18777
+              final Lazy<Global.TGlobal> arg$19146
             ) -> {
-                  final PreludeBase.TTuple2<Range.TRange, Global.TGlobal> $18778 = v7688$18604
-                  .apply(arg$18777).call();
-                  final State.TState<Global.TGlobal, TDiagnostic> $18779 = State.IMonad_State.<
+                  final PreludeBase.TTuple2<Range.TRange, Global.TGlobal> $19147 = v7688$18973
+                  .apply(arg$19146).call();
+                  final State.TState<Global.TGlobal, TDiagnostic> $19148 = State.IMonad_State.<
                     Global.TGlobal, TDiagnostic
                   >pure(
                         TDiagnostic.mk(
-                              $18778.mem1,
+                              $19147.mem1,
                               Thunk.<Short>shared(
                                     (Lazy<Short>)(() -> Diagnostic.fromCompilerSeverity(
                                               Global.TMessage.level(arg$1)
@@ -1495,11 +1507,11 @@ final public static State.TState<Global.TGlobal, TDiagnostic> createDiagnosticFr
                               Thunk.<String/*<Character>*/>lazy(Global.TMessage.text(arg$1))
                             )
                       );
-                  final Func.U<Global.TGlobal, PreludeBase.TTuple2<TDiagnostic, Global.TGlobal>> v7693$18609 =
-                  $18779.mem$fun;
+                  final Func.U<Global.TGlobal, PreludeBase.TTuple2<TDiagnostic, Global.TGlobal>> v7693$18978 =
+                  $19148.mem$fun;
                   return Thunk.<PreludeBase.TTuple2<TDiagnostic, Global.TGlobal>>nested(
-                            (Lazy<Lazy<PreludeBase.TTuple2<TDiagnostic, Global.TGlobal>>>)(() -> v7693$18609
-                                .apply($18778.mem2))
+                            (Lazy<Lazy<PreludeBase.TTuple2<TDiagnostic, Global.TGlobal>>>)(() -> v7693$18978
+                                .apply($19147.mem2))
                           );
                 })
           );
@@ -1507,32 +1519,32 @@ final public static State.TState<Global.TGlobal, TDiagnostic> createDiagnosticFr
 final public static State.TState<Global.TGlobal, PreludeBase.TList<TDiagnostic>> extractDiagnostics =
 State.TState.<Global.TGlobal, PreludeBase.TList<TDiagnostic>>mk(
       (Func.U<Global.TGlobal, PreludeBase.TTuple2<PreludeBase.TList<TDiagnostic>, Global.TGlobal>>)((
-        final Lazy<Global.TGlobal> arg$18781
+        final Lazy<Global.TGlobal> arg$19150
       ) -> {
-            final Global.TGlobal v7690$18571 = arg$18781.call();
-            final State.TState<Global.TGlobal, PreludeBase.TList<TDiagnostic>> $18784 =
+            final Global.TGlobal v7690$18940 = arg$19150.call();
+            final State.TState<Global.TGlobal, PreludeBase.TList<TDiagnostic>> $19153 =
             State.TState.<Global.TGlobal, PreludeBase.TList<TDiagnostic>>coerce(
                   PreludeMonad.<State.TState<Global.TGlobal, ?>, TDiagnostic>sequence(
                         State.IMonad_State.<Global.TGlobal>mk(), State.IMonad_State.<Global.TGlobal>mk(),
                         PreludeMonad.IFunctor_$lbrack$rbrack.<Global.TMessage, State.TState<Global.TGlobal, TDiagnostic>>fmap(
                               (Func.U<Global.TMessage, State.TState<Global.TGlobal, TDiagnostic>>)((
-                                final Lazy<Global.TMessage> η$18783
+                                final Lazy<Global.TMessage> η$19152
                               ) -> Thunk.<State.TState<Global.TGlobal, TDiagnostic>>shared(
                                         (Lazy<State.TState<
                                           Global.TGlobal, TDiagnostic
                                         >>)(() -> Diagnostic.createDiagnosticFromMessage(
-                                                  η$18783.call()
+                                                  η$19152.call()
                                                 ))
                                       )),
-                              Global.TSubSt.messages(Global.TGlobal.sub(v7690$18571))
+                              Global.TSubSt.messages(Global.TGlobal.sub(v7690$18940))
                             ).<Kind.U<State.TState<Global.TGlobal, ?>, TDiagnostic>>simsalabim()
                       )
                 );
-            final Func.U<Global.TGlobal, PreludeBase.TTuple2<PreludeBase.TList<TDiagnostic>, Global.TGlobal>> v7693$18574 =
-            $18784.mem$fun;
+            final Func.U<Global.TGlobal, PreludeBase.TTuple2<PreludeBase.TList<TDiagnostic>, Global.TGlobal>> v7693$18943 =
+            $19153.mem$fun;
             return Thunk.<PreludeBase.TTuple2<PreludeBase.TList<TDiagnostic>, Global.TGlobal>>nested(
-                      (Lazy<Lazy<PreludeBase.TTuple2<PreludeBase.TList<TDiagnostic>, Global.TGlobal>>>)(() -> v7693$18574
-                          .apply(v7690$18571))
+                      (Lazy<Lazy<PreludeBase.TTuple2<PreludeBase.TList<TDiagnostic>, Global.TGlobal>>>)(() -> v7693$18943
+                          .apply(v7690$18940))
                     );
           })
     );
@@ -1554,19 +1566,19 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$18786) -> {
-                                            final Global.TGlobal v2056$18404 = CompileGlobal.standardCompileGlobal
-                                            .call().apply(arg$18786).call();
-                                            final Func.U<RealWorld, Global.TGlobal> v2053$18423 =
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$19155) -> {
+                                            final Global.TGlobal v2056$18773 = CompileGlobal.standardCompileGlobal
+                                            .call().apply(arg$19155).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$18792 =
                                             CompileExecutor.compile(
                                                   Thunk.<String/*<Character>*/>lazy(
                                                         "module ch.fhnw.thga.FaultyFregeTest where\n\nimport Does.not.Exist"
                                                       ),
-                                                  v2056$18404
+                                                  v2056$18773
                                                 );
-                                            final Global.TGlobal v2056$18426 = v2053$18423
-                                            .apply(arg$18786).call();
-                                            final Func.U<RealWorld, Boolean> v2057$18427 =
+                                            final Global.TGlobal v2056$18795 = v2053$18792
+                                            .apply(arg$19155).call();
+                                            final Func.U<RealWorld, Boolean> v2057$18796 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> PreludeBase.IEq_$lbrack$rbrack.<
@@ -1621,15 +1633,15 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                         (Lazy<PreludeBase.TList<
                                                                           TDiagnostic
                                                                         >>)(() -> Diagnostic.getDiagnostics(
-                                                                                  v2056$18426
+                                                                                  v2056$18795
                                                                                 ))
                                                                       )
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18427
-                                                          .apply(arg$18786))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18796
+                                                          .apply(arg$19155))
                                                     );
                                           })
                                     ))
@@ -1652,21 +1664,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$18791) -> {
-                                            final Global.TGlobal v2056$18520 = CompileGlobal.standardCompileGlobal
-                                            .call().apply(arg$18791).call();
-                                            final Func.U<RealWorld, Global.TGlobal> v2053$18539 =
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$19160) -> {
+                                            final Global.TGlobal v2056$18889 = CompileGlobal.standardCompileGlobal
+                                            .call().apply(arg$19160).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$18908 =
                                             CompileExecutor.compile(
                                                   Thunk.<String/*<Character>*/>shared(
                                                         (Lazy<String/*
                                                           <Character>
                                                         */>)(() -> "module CorrectFregeTest where\n\n" + "ok = 42 + 42")
                                                       ),
-                                                  v2056$18520
+                                                  v2056$18889
                                                 );
-                                            final Global.TGlobal v2056$18542 = v2053$18539
-                                            .apply(arg$18791).call();
-                                            final Func.U<RealWorld, Boolean> v2057$18543 =
+                                            final Global.TGlobal v2056$18911 = v2053$18908
+                                            .apply(arg$19160).call();
+                                            final Func.U<RealWorld, Boolean> v2057$18912 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> PreludeBase.IEq_$lbrack$rbrack.<
@@ -1677,15 +1689,15 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                         (Lazy<PreludeBase.TList<
                                                                           TDiagnostic
                                                                         >>)(() -> Diagnostic.getDiagnostics(
-                                                                                  v2056$18542
+                                                                                  v2056$18911
                                                                                 ))
                                                                       )
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18543
-                                                          .apply(arg$18791))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18912
+                                                          .apply(arg$19160))
                                                     );
                                           })
                                     ))
@@ -1708,19 +1720,19 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$18796) -> {
-                                            final Global.TGlobal v2056$18462 = CompileGlobal.standardCompileGlobal
-                                            .call().apply(arg$18796).call();
-                                            final Func.U<RealWorld, Global.TGlobal> v2053$18481 =
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$19165) -> {
+                                            final Global.TGlobal v2056$18831 = CompileGlobal.standardCompileGlobal
+                                            .call().apply(arg$19165).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$18850 =
                                             CompileExecutor.compile(
                                                   Thunk.<String/*<Character>*/>lazy(
                                                         "module ch.fhnw.thga.FaultyFregeTest where\n\nerr1 = do\n  x = 42\n\nerr2 = [ 22.0 ] ++ \"42\"\n\nerr3 = 42 + \"42\""
                                                       ),
-                                                  v2056$18462
+                                                  v2056$18831
                                                 );
-                                            final Global.TGlobal v2056$18484 = v2053$18481
-                                            .apply(arg$18796).call();
-                                            final Func.U<RealWorld, Boolean> v2057$18485 =
+                                            final Global.TGlobal v2056$18853 = v2053$18850
+                                            .apply(arg$19165).call();
+                                            final Func.U<RealWorld, Boolean> v2057$18854 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> PreludeBase.IEq_$lbrack$rbrack.<
@@ -1885,15 +1897,15 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                         (Lazy<PreludeBase.TList<
                                                                           TDiagnostic
                                                                         >>)(() -> Diagnostic.getDiagnostics(
-                                                                                  v2056$18484
+                                                                                  v2056$18853
                                                                                 ))
                                                                       )
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18485
-                                                          .apply(arg$18796))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$18854
+                                                          .apply(arg$19165))
                                                     );
                                           })
                                     ))

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.java
@@ -28,8 +28,10 @@ import frege.Prelude;
 import frege.Version;
 import frege.compiler.Classes;
 import frege.compiler.Classtools;
+import frege.compiler.GenMeta;
 import frege.compiler.Javatypes;
 import frege.compiler.Kinds;
+import frege.compiler.Main;
 import frege.compiler.Typecheck;
 import frege.compiler.Utilities;
 import frege.compiler.classes.Nice;
@@ -58,8 +60,16 @@ import frege.compiler.enums.RFlag;
 import frege.compiler.enums.SymState;
 import frege.compiler.enums.TokenID;
 import frege.compiler.enums.Visibility;
+import frege.compiler.gen.java.Bindings;
 import frege.compiler.gen.java.Common;
+import frege.compiler.gen.java.Constants;
+import frege.compiler.gen.java.DataCode;
+import frege.compiler.gen.java.InstanceCode;
+import frege.compiler.gen.java.Instantiation;
+import frege.compiler.gen.java.Match;
+import frege.compiler.gen.java.MethodCall;
 import frege.compiler.gen.java.PrettyJava;
+import frege.compiler.gen.java.VarCode;
 import frege.compiler.grammar.Frege;
 import frege.compiler.grammar.Lexer;
 import frege.compiler.instances.NiceExprS;
@@ -70,6 +80,7 @@ import frege.compiler.passes.Enter;
 import frege.compiler.passes.Fields;
 import frege.compiler.passes.Final;
 import frege.compiler.passes.Fix;
+import frege.compiler.passes.GenCode;
 import frege.compiler.passes.GlobalLam;
 import frege.compiler.passes.Imp;
 import frege.compiler.passes.Instances;
@@ -98,6 +109,7 @@ import frege.compiler.types.Symbols;
 import frege.compiler.types.Targets;
 import frege.compiler.types.Tokens;
 import frege.control.Category;
+import frege.control.Concurrent;
 import frege.control.Semigroupoid;
 import frege.control.monad.State;
 import frege.control.monad.trans.MonadIO;
@@ -143,7 +155,7 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/DiagnosticLSP.fr",
-  time=1659200054226L, jmajor=11, jminor=-1,
+  time=1659433741713L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.diagnostic.Diagnostic", "frege.compiler.types.Global", "frege.Prelude",
     "frege.prelude.PreludeArrays", "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal",
@@ -373,13 +385,13 @@ final public static class TDiagnosticSeverityLSP  {
 }
 final public static class TDiagnosticLSP  {
   final public static org.eclipse.lsp4j.Diagnostic fromDiagnostic(final Diagnostic.TDiagnostic arg$1) {
-    final String/*<Character>*/ message$17368 = arg$1.mem$message.call();
-    final String/*<Character>*/ source$17367 = arg$1.mem$source.call();
-    final short severity$17366 = (short)arg$1.mem$severity.call();
-    final Range.TRange range$17365 = arg$1.mem$range.call();
+    final String/*<Character>*/ message$17737 = arg$1.mem$message.call();
+    final String/*<Character>*/ source$17736 = arg$1.mem$source.call();
+    final short severity$17735 = (short)arg$1.mem$severity.call();
+    final Range.TRange range$17734 = arg$1.mem$range.call();
     return new org.eclipse.lsp4j.Diagnostic(
-          RangeLSP4J.TRangeLSP.fromRange(range$17365), message$17368,
-          TDiagnosticSeverityLSP.fromCompilerSeverity(severity$17366), source$17367
+          RangeLSP4J.TRangeLSP.fromRange(range$17734), message$17737,
+          TDiagnosticSeverityLSP.fromCompilerSeverity(severity$17735), source$17736
         );
   }
 }
@@ -397,15 +409,15 @@ final public static class TArrayList  {
             });
   }
   final public static <𝓐, 𝓢> Func.U<𝓢, java.util.ArrayList<𝓐>> fromFregeList(final Lazy<PreludeBase.TList<𝓐>> arg$1) {
-    return (Func.U<𝓢, java.util.ArrayList<𝓐>>)((final Lazy<𝓢> arg$17494) -> {
-              final java.util.ArrayList<𝓐> v2056$17474 = TArrayList.<𝓐, 𝓢>$new(PreludeBase.TUnit.Unit)
-              .apply(arg$17494).call();
-              final Func.U<𝓢, java.util.ArrayList<𝓐>> v2057$17475 = DiagnosticLSP.<𝓐, 𝓢>go(
-                    arg$1.call(), Thunk.<java.util.ArrayList<𝓐>>lazy(v2056$17474)
+    return (Func.U<𝓢, java.util.ArrayList<𝓐>>)((final Lazy<𝓢> arg$17863) -> {
+              final java.util.ArrayList<𝓐> v2056$17843 = TArrayList.<𝓐, 𝓢>$new(PreludeBase.TUnit.Unit)
+              .apply(arg$17863).call();
+              final Func.U<𝓢, java.util.ArrayList<𝓐>> v2057$17844 = DiagnosticLSP.<𝓐, 𝓢>go(
+                    arg$1.call(), Thunk.<java.util.ArrayList<𝓐>>lazy(v2056$17843)
                   );
               return Thunk.<java.util.ArrayList<𝓐>>nested(
-                        (Lazy<Lazy<java.util.ArrayList<𝓐>>>)(() -> v2057$17475.apply(
-                                  arg$17494
+                        (Lazy<Lazy<java.util.ArrayList<𝓐>>>)(() -> v2057$17844.apply(
+                                  arg$17863
                                 ))
                       );
             });
@@ -419,26 +431,26 @@ final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWor
 final public static <𝓐, 𝓢> Func.U<𝓢, java.util.ArrayList<𝓐>> go(
   final PreludeBase.TList<𝓐> arg$1, final Lazy<java.util.ArrayList<𝓐>> arg$2
 ) {
-  final PreludeBase.TList.DCons<𝓐> $17497 = arg$1.asCons();
-  if ($17497 != null) {
-    final 𝓐 µ$$17381 = $17497.mem1.call();
-    return (Func.U<𝓢, java.util.ArrayList<𝓐>>)((final Lazy<𝓢> arg$17499) -> {
-              final boolean v4796$17450 = (boolean)TArrayList.<𝓐, 𝓢>add(arg$2.call(), µ$$17381)
-              .apply(arg$17499).call();
-              final Func.U<𝓢, java.util.ArrayList<𝓐>> v4797$17451 = Thunk.<Func.U<𝓢, java.util.ArrayList<𝓐>>>shared(
+  final PreludeBase.TList.DCons<𝓐> $17866 = arg$1.asCons();
+  if ($17866 != null) {
+    final 𝓐 µ$$17750 = $17866.mem1.call();
+    return (Func.U<𝓢, java.util.ArrayList<𝓐>>)((final Lazy<𝓢> arg$17868) -> {
+              final boolean v4796$17819 = (boolean)TArrayList.<𝓐, 𝓢>add(arg$2.call(), µ$$17750)
+              .apply(arg$17868).call();
+              final Func.U<𝓢, java.util.ArrayList<𝓐>> v4797$17820 = Thunk.<Func.U<𝓢, java.util.ArrayList<𝓐>>>shared(
                     (Lazy<Func.U<𝓢, java.util.ArrayList<𝓐>>>)(() -> DiagnosticLSP.<𝓐, 𝓢>go(
-                              $17497.mem2.call(), arg$2
+                              $17866.mem2.call(), arg$2
                             ))
                   ).call();
               return Thunk.<java.util.ArrayList<𝓐>>nested(
-                        (Lazy<Lazy<java.util.ArrayList<𝓐>>>)(() -> v4797$17451.apply(
-                                  arg$17499
+                        (Lazy<Lazy<java.util.ArrayList<𝓐>>>)(() -> v4797$17820.apply(
+                                  arg$17868
                                 ))
                       );
             });
   }
-  final PreludeBase.TList.DList<𝓐> $17502 = arg$1.asList();
-  assert $17502 != null;
+  final PreludeBase.TList.DList<𝓐> $17871 = arg$1.asList();
+  assert $17871 != null;
   return PreludeMonad.IMonad_ST.<𝓢, java.util.ArrayList<𝓐>>pure(arg$2);
 }
 final public static <𝓢> Func.U<𝓢, java.util.ArrayList<org.eclipse.lsp4j.Diagnostic>> getDiagnosticsLSP(
@@ -450,10 +462,10 @@ final public static <𝓢> Func.U<𝓢, java.util.ArrayList<org.eclipse.lsp4j.Di
                         Diagnostic.TDiagnostic, org.eclipse.lsp4j.Diagnostic
                       >fmap(
                             (Func.U<Diagnostic.TDiagnostic, org.eclipse.lsp4j.Diagnostic>)((
-                              final Lazy<Diagnostic.TDiagnostic> η$17503
+                              final Lazy<Diagnostic.TDiagnostic> η$17872
                             ) -> Thunk.<org.eclipse.lsp4j.Diagnostic>shared(
                                       (Lazy<org.eclipse.lsp4j.Diagnostic>)(() -> TDiagnosticLSP.fromDiagnostic(
-                                                η$17503.call()
+                                                η$17872.call()
                                               ))
                                     )),
                             Diagnostic.getDiagnostics(arg$1)

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/Hover.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/Hover.java
@@ -153,7 +153,7 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr",
-  time=1659200053754L, jmajor=11, jminor=-1,
+  time=1659433741239L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.compile.CompileExecutor",
     "ch.fhnw.thga.fregelanguageserver.compile.CompileGlobal", "frege.compiler.types.Global", "frege.data.List",
@@ -792,10 +792,10 @@ final public static class IShow_FregeCodeBlock implements PreludeText.CShow<Stri
               Thunk.<String/*<Character>*/>lazy(", "),
               PreludeList.<String/*<Character>*/, String/*<Character>*/>map(
                     (Func.U<String/*<Character>*/, String/*<Character>*/>)((
-                      final Lazy<String/*<Character>*/> η$20270
+                      final Lazy<String/*<Character>*/> η$20271
                     ) -> Thunk.<String/*<Character>*/>shared(
                               (Lazy<String/*<Character>*/>)(() -> IShow_FregeCodeBlock.show(
-                                        η$20270.call()
+                                        η$20271.call()
                                       ))
                             )),
                     arg$1
@@ -843,19 +843,19 @@ final public static class IShow_Hover implements PreludeText.CShow<THover> {
     return IShow_Hover.showChars(arg$1.call());
   }
   final public static String/*<Character>*/ showsub(final THover arg$1) {
-    final String/*<Character>*/ a2$18203 = arg$1.mem$content.call();
-    final Range.TRange a1$18202 = arg$1.mem$range.call();
-    return ("(" + (((("Hover" + " ") + Range.IShow_Range.showsub(a1$18202)) + " ") + IShow_FregeCodeBlock.showsub(
-              a2$18203
+    final String/*<Character>*/ a2$18204 = arg$1.mem$content.call();
+    final Range.TRange a1$18203 = arg$1.mem$range.call();
+    return ("(" + (((("Hover" + " ") + Range.IShow_Range.showsub(a1$18203)) + " ") + IShow_FregeCodeBlock.showsub(
+              a2$18204
             ))) + ")";
   }
   final public static String/*<Character>*/ showList(final PreludeBase.TList<THover> arg$1, final String/*<Character>*/ arg$2) {
     return "[" + (PreludeText.joined(
               Thunk.<String/*<Character>*/>lazy(", "),
               PreludeList.<String/*<Character>*/, THover>map(
-                    (Func.U<THover, String/*<Character>*/>)((final Lazy<THover> η$20282) -> Thunk.<
+                    (Func.U<THover, String/*<Character>*/>)((final Lazy<THover> η$20283) -> Thunk.<
                           String/*<Character>*/
-                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_Hover.show(η$20282.call())))),
+                        >shared((Lazy<String/*<Character>*/>)(() -> IShow_Hover.show(η$20283.call())))),
                     arg$1
                   )
             ).call() + ("]" + arg$2));
@@ -869,10 +869,10 @@ final public static class IShow_Hover implements PreludeText.CShow<THover> {
     return IShow_Hover.show(arg$1);
   }
   final public static String/*<Character>*/ show(final THover arg$1) {
-    final String/*<Character>*/ a2$18200 = arg$1.mem$content.call();
-    final Range.TRange a1$18199 = arg$1.mem$range.call();
-    return ((("Hover" + " ") + Range.IShow_Range.showsub(a1$18199)) + " ") + IShow_FregeCodeBlock.showsub(
-              a2$18200
+    final String/*<Character>*/ a2$18201 = arg$1.mem$content.call();
+    final Range.TRange a1$18200 = arg$1.mem$range.call();
+    return ((("Hover" + " ") + Range.IShow_Range.showsub(a1$18200)) + " ") + IShow_FregeCodeBlock.showsub(
+              a2$18201
             );
   }
   final public static PreludeBase.TList<Character> showChars(final THover arg$1) {
@@ -919,11 +919,11 @@ final public static class IEq_Hover implements PreludeBase.CEq<THover> {
     return IEq_Hover.$eq$eq(arg$1.call(), arg$2.call());
   }
   final public static int hashCode(final THover arg$1) {
-    final String/*<Character>*/ a2$18197 = arg$1.mem$content.call();
-    final Range.TRange a1$18196 = arg$1.mem$range.call();
+    final String/*<Character>*/ a2$18198 = arg$1.mem$content.call();
+    final Range.TRange a1$18197 = arg$1.mem$range.call();
     return (31 * ((31 * ((31 * 1) + RunTM.constructor(arg$1))) + Range.IEq_Range.hashCode(
-              a1$18196
-            ))) + IEq_FregeCodeBlock.hashCode(a2$18197);
+              a1$18197
+            ))) + IEq_FregeCodeBlock.hashCode(a2$18198);
   }
   final public static boolean $excl$eq(final THover arg$1, final THover arg$2) {
     if (IEq_Hover.$eq$eq(arg$1, arg$2)) {
@@ -934,11 +934,11 @@ final public static class IEq_Hover implements PreludeBase.CEq<THover> {
     }
   }
   final public static boolean $eq$eq(final THover arg$1, final THover arg$2) {
-    final String/*<Character>*/ µ$$18267 = arg$1.mem$content.call();
-    final Range.TRange µ$$18266 = arg$1.mem$range.call();
-    final String/*<Character>*/ µ$$18269 = arg$2.mem$content.call();
-    final Range.TRange µ$$18268 = arg$2.mem$range.call();
-    return Range.IEq_Range.$eq$eq(µ$$18266, µ$$18268) && IEq_FregeCodeBlock.$eq$eq(µ$$18267, µ$$18269);
+    final String/*<Character>*/ µ$$18268 = arg$1.mem$content.call();
+    final Range.TRange µ$$18267 = arg$1.mem$range.call();
+    final String/*<Character>*/ µ$$18270 = arg$2.mem$content.call();
+    final Range.TRange µ$$18269 = arg$2.mem$range.call();
+    return Range.IEq_Range.$eq$eq(µ$$18267, µ$$18269) && IEq_FregeCodeBlock.$eq$eq(µ$$18268, µ$$18270);
   }
 }
 final public static class THover implements frege.runtime.Value, Lazy<THover> {
@@ -979,8 +979,8 @@ final public static class THover implements frege.runtime.Value, Lazy<THover> {
     return true;
   }
   final public static Range.TRange range(final THover arg$1) {
-    final Range.TRange a1$18116 = arg$1.mem$range.call();
-    return a1$18116;
+    final Range.TRange a1$18117 = arg$1.mem$range.call();
+    return a1$18117;
   }
   final public static THover chg$range(final THover arg$1, final Lazy<Func.U<Range.TRange, Range.TRange>> arg$2) {
     return THover.mk(
@@ -999,8 +999,8 @@ final public static class THover implements frege.runtime.Value, Lazy<THover> {
             );
   }
   final public static String/*<Character>*/ content(final THover arg$1) {
-    final String/*<Character>*/ a2$18105 = arg$1.mem$content.call();
-    return a2$18105;
+    final String/*<Character>*/ a2$18106 = arg$1.mem$content.call();
+    return a2$18106;
   }
 }
 public static abstract class TFregeCodeBlock  {
@@ -1026,12 +1026,12 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.
 ) {
   return State.TStateT.<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.TQName>mk(
             (Func.U<Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>>)((
-              final Lazy<Global.TGlobal> arg$20303
+              final Lazy<Global.TGlobal> arg$20304
             ) -> {
-                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$19230 =
-                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20303, arg$20303)
+                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$19231 =
+                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20304, arg$20304)
                   .call();
-                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, PreludeBase.TEither<Short, QNames.TQName>> $20305 =
+                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, PreludeBase.TEither<Short, QNames.TQName>> $20306 =
                   State.IMonadTrans_StateT.<
                     Global.TGlobal, PreludeBase.TEither<Short, QNames.TQName>, PreludeBase.TMaybe<?>
                   >lift(
@@ -1042,7 +1042,7 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.
                                   >)Thunk.<PreludeBase.TMaybe<PreludeBase.TEither<Short, QNames.TQName>>>shared(
                                         (Lazy<PreludeBase.TMaybe<
                                           PreludeBase.TEither<Short, QNames.TQName>
-                                        >>)(() -> Global.TGlobal.resolved(v2895$19230.mem1.call(), arg$1))
+                                        >>)(() -> Global.TGlobal.resolved(v2895$19231.mem1.call(), arg$1))
                                       ).call())
                             )
                       );
@@ -1051,22 +1051,22 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.
                     Kind.U<
                       PreludeBase.TMaybe<?>, PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal>
                     >
-                  > v7734$19259 = $20305.mem$run;
+                  > v7734$19260 = $20306.mem$run;
                   final PreludeBase.TMaybe<
                     PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal>
-                  > $20307 = RunTM.<
+                  > $20308 = RunTM.<
                     Func.U<
                       Global.TGlobal,
                       PreludeBase.TMaybe<PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal>>
                     >
-                  >cast(v7734$19259).apply(v2895$19230.mem2).call();
+                  >cast(v7734$19260).apply(v2895$19231.mem2).call();
                   final PreludeBase.TMaybe.DJust<
                     PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal>
-                  > $20308 = $20307.asJust();
-                  if ($20308 != null) {
-                    final PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal> v2895$19291 =
-                    $20308.mem1.call();
-                    final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.TQName> $20312 =
+                  > $20309 = $20308.asJust();
+                  if ($20309 != null) {
+                    final PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal> v2895$19292 =
+                    $20309.mem1.call();
+                    final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.TQName> $20313 =
                     State.IMonadTrans_StateT.<Global.TGlobal, QNames.TQName, PreludeBase.TMaybe<?>>lift(
                           Maybe.IMonad_Maybe.it,
                           Thunk.<Kind.U<PreludeBase.TMaybe<?>, QNames.TQName>>shared(
@@ -1077,29 +1077,29 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.
                                                 PreludeBase.TMaybe<QNames.TQName>, Short, QNames.TQName
                                               >either(
                                                     (Func.U<Short, PreludeBase.TMaybe<QNames.TQName>>)((
-                                                      final Lazy<Short> η$20310
+                                                      final Lazy<Short> η$20311
                                                     ) -> Thunk.<PreludeBase.TMaybe<QNames.TQName>>shared(
                                                               (Lazy<PreludeBase.TMaybe<
                                                                 QNames.TQName
                                                               >>)(() -> PreludeBase.<
                                                                     Short, PreludeBase.TMaybe<QNames.TQName>
                                                                   >$const(
-                                                                        PreludeBase.TMaybe.DNothing.<QNames.TQName>mk(), η$20310
+                                                                        PreludeBase.TMaybe.DNothing.<QNames.TQName>mk(), η$20311
                                                                       ))
                                                             )),
                                                     (Func.U<QNames.TQName, PreludeBase.TMaybe<QNames.TQName>>)((
-                                                      final Lazy<QNames.TQName> η$20311
+                                                      final Lazy<QNames.TQName> η$20312
                                                     ) -> PreludeBase.TMaybe.DJust.<QNames.TQName>mk(
-                                                              η$20311
+                                                              η$20312
                                                             )),
-                                                    v2895$19291.mem1.call()
+                                                    v2895$19292.mem1.call()
                                                   ))
                                         ).call())
                               )
                         );
                     final Func.U<
                       Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>
-                    > v7739$19264 = $20312.mem$run;
+                    > v7739$19265 = $20313.mem$run;
                     return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>>shared(
                               (Lazy<Kind.U<
                                 PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>
@@ -1113,14 +1113,14 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.
                                                 Global.TGlobal,
                                                 PreludeBase.TMaybe<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>
                                               >
-                                            >cast(v7739$19264).apply(v2895$19291.mem2))
+                                            >cast(v7739$19265).apply(v2895$19292.mem2))
                                       ).call())
                             );
                   }
                   final PreludeBase.TMaybe.DNothing<
                     PreludeBase.TTuple2<PreludeBase.TEither<Short, QNames.TQName>, Global.TGlobal>
-                  > $20314 = $20307.asNothing();
-                  assert $20314 != null;
+                  > $20315 = $20308.asNothing();
+                  assert $20315 != null;
                   return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>>lazy(
                             (Kind.U<
                               PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>
@@ -1135,17 +1135,17 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/
   return State.TStateT.<Global.TGlobal, PreludeBase.TMaybe<?>, String/*<Character>*/>mk(
             (Func.U<
               Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>>
-            >)((final Lazy<Global.TGlobal> arg$20315) -> {
-                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$20071 =
-                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20315, arg$20315)
+            >)((final Lazy<Global.TGlobal> arg$20316) -> {
+                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$20072 =
+                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20316, arg$20316)
                   .call();
-                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/*<Character>*/> $20317 =
+                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/*<Character>*/> $20318 =
                   State.IMonad_StateT.<Global.TGlobal, PreludeBase.TMaybe<?>, String/*<Character>*/>pure(
-                        Maybe.IMonad_Maybe.it, frege.ide.Utilities.<Global.TGlobal>label(v2895$20071.mem1, arg$1.call())
+                        Maybe.IMonad_Maybe.it, frege.ide.Utilities.<Global.TGlobal>label(v2895$20072.mem1, arg$1.call())
                       );
                   final Func.U<
                     Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>>
-                  > v7739$20044 = $20317.mem$run;
+                  > v7739$20045 = $20318.mem$run;
                   return Thunk.<
                         Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>>
                       >shared(
@@ -1161,7 +1161,7 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/
                                               Global.TGlobal,
                                               PreludeBase.TMaybe<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>>
                                             >
-                                          >cast(v7739$20044).apply(v2895$20071.mem2))
+                                          >cast(v7739$20045).apply(v2895$20072.mem2))
                                     ).call())
                           );
                 })
@@ -1170,9 +1170,9 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/
 final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.TToken> findToken(
   final Lazy<Position.TPosition> arg$1
 ) {
-  final class Let$20319  {
-    final Let$20319 let$20319 = this;
-    final public boolean isHoverOverToken$18130(final Tokens.TToken arg$2) {
+  final class Let$20320  {
+    final Let$20320 let$20320 = this;
+    final public boolean isHoverOverToken$18131(final Tokens.TToken arg$2) {
       return (Position.TPosition.line(arg$1.call()) == Tokens.TToken.line(arg$2)) && ((Position.TPosition.character(
                 arg$1.call()
               ) < (Tokens.TToken.col(arg$2) + Tokens.TToken.value(arg$2).length())) && (Position.TPosition.character(
@@ -1180,15 +1180,15 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.
               ) >= Tokens.TToken.col(arg$2)));
     }
   }
-  final Let$20319 let$20319 = new Let$20319();
+  final Let$20320 let$20320 = new Let$20320();
   return State.TStateT.<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.TToken>mk(
             (Func.U<Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>>>)((
-              final Lazy<Global.TGlobal> arg$20320
+              final Lazy<Global.TGlobal> arg$20321
             ) -> {
-                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$20207 =
-                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20320, arg$20320)
+                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$20208 =
+                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20321, arg$20321)
                   .call();
-                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.TToken> $20323 =
+                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.TToken> $20324 =
                   State.IMonadTrans_StateT.<Global.TGlobal, Tokens.TToken, PreludeBase.TMaybe<?>>lift(
                         Maybe.IMonad_Maybe.it,
                         Thunk.<Kind.U<PreludeBase.TMaybe<?>, Tokens.TToken>>shared(
@@ -1199,11 +1199,11 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.
                                               Tokens.TToken
                                             >find(
                                                   (Func.U<Tokens.TToken, Boolean>)((
-                                                    final Lazy<Tokens.TToken> η$20322
+                                                    final Lazy<Tokens.TToken> η$20323
                                                   ) -> Thunk.<Boolean>shared(
-                                                            (Lazy<Boolean>)(() -> let$20319
-                                                                .isHoverOverToken$18130(
-                                                                      η$20322.call()
+                                                            (Lazy<Boolean>)(() -> let$20320
+                                                                .isHoverOverToken$18131(
+                                                                      η$20323.call()
                                                                     ))
                                                           )),
                                                   Thunk.<PreludeBase.TList<Tokens.TToken>>shared(
@@ -1212,7 +1212,7 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.
                                                         >>)(() -> Tokens.IArrayElement_Token.listFromArray(
                                                                   Global.TSubSt.toks(
                                                                         Global.TGlobal.sub(
-                                                                              v2895$20207.mem1
+                                                                              v2895$20208.mem1
                                                                               .call()
                                                                             )
                                                                       )
@@ -1224,7 +1224,7 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.
                       );
                   final Func.U<
                     Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>>
-                  > v7739$20180 = $20323.mem$run;
+                  > v7739$20181 = $20324.mem$run;
                   return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>>>shared(
                             (Lazy<Kind.U<
                               PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>
@@ -1238,7 +1238,7 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.
                                               Global.TGlobal,
                                               PreludeBase.TMaybe<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>>
                                             >
-                                          >cast(v7739$20180).apply(v2895$20207.mem2))
+                                          >cast(v7739$20181).apply(v2895$20208.mem2))
                                     ).call())
                           );
                 })
@@ -1251,11 +1251,11 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols
             (Func.U<
               Global.TGlobal,
               Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>>
-            >)((final Lazy<Global.TGlobal> arg$20325) -> {
-                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$20139 =
-                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20325, arg$20325)
+            >)((final Lazy<Global.TGlobal> arg$20326) -> {
+                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$20140 =
+                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20326, arg$20326)
                   .call();
-                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols.TSymbolT<Global.TGlobal>> $20327 =
+                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols.TSymbolT<Global.TGlobal>> $20328 =
                   State.IMonadTrans_StateT.<Global.TGlobal, Symbols.TSymbolT<Global.TGlobal>, PreludeBase.TMaybe<?>>lift(
                         Maybe.IMonad_Maybe.it,
                         Thunk.<Kind.U<PreludeBase.TMaybe<?>, Symbols.TSymbolT<Global.TGlobal>>>shared(
@@ -1264,14 +1264,14 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols
                                   >)Thunk.<PreludeBase.TMaybe<Symbols.TSymbolT<Global.TGlobal>>>nested(
                                         (Lazy<Lazy<PreludeBase.TMaybe<
                                           Symbols.TSymbolT<Global.TGlobal>
-                                        >>>)(() -> Global.TGlobal.find(v2895$20139.mem1.call(), arg$1.call()))
+                                        >>>)(() -> Global.TGlobal.find(v2895$20140.mem1.call(), arg$1.call()))
                                       ).call())
                             )
                       );
                   final Func.U<
                     Global.TGlobal,
                     Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>>
-                  > v7739$20112 = $20327.mem$run;
+                  > v7739$20113 = $20328.mem$run;
                   return Thunk.<
                         Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>>
                       >shared(
@@ -1291,7 +1291,7 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols
                                                 PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>
                                               >
                                             >
-                                          >cast(v7739$20112).apply(v2895$20139.mem2))
+                                          >cast(v7739$20113).apply(v2895$20140.mem2))
                                     ).call())
                           );
                 })
@@ -1302,88 +1302,88 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover>
 ) {
   return State.TStateT.<Global.TGlobal, PreludeBase.TMaybe<?>, THover>mk(
             (Func.U<Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>>)((
-              final Lazy<Global.TGlobal> arg$20329
+              final Lazy<Global.TGlobal> arg$20330
             ) -> {
-                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$19820 =
-                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20329, arg$20329)
+                  final PreludeBase.TTuple2<Global.TGlobal, Global.TGlobal> v2895$19821 =
+                  PreludeBase.TTuple2.<Global.TGlobal, Global.TGlobal>mk(arg$20330, arg$20330)
                   .call();
-                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.TToken> $20331 =
+                  final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Tokens.TToken> $20332 =
                   Hover.findToken(arg$1);
                   final Func.U<
                     Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>>
-                  > v7734$19849 = $20331.mem$run;
-                  final PreludeBase.TMaybe<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>> $20333 =
+                  > v7734$19850 = $20332.mem$run;
+                  final PreludeBase.TMaybe<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>> $20334 =
                   RunTM.<Func.U<Global.TGlobal, PreludeBase.TMaybe<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>>>>cast(
-                        v7734$19849
-                      ).apply(v2895$19820.mem2).call();
-                  final PreludeBase.TMaybe.DJust<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>> $20334 =
-                  $20333.asJust();
-                  if ($20334 != null) {
-                    final PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal> v2895$19881 =
-                    $20334.mem1.call();
-                    final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.TQName> $20336 =
-                    Hover.tokenToQName(v2895$19881.mem1);
+                        v7734$19850
+                      ).apply(v2895$19821.mem2).call();
+                  final PreludeBase.TMaybe.DJust<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>> $20335 =
+                  $20334.asJust();
+                  if ($20335 != null) {
+                    final PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal> v2895$19882 =
+                    $20335.mem1.call();
+                    final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, QNames.TQName> $20337 =
+                    Hover.tokenToQName(v2895$19882.mem1);
                     final Func.U<
                       Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>
-                    > v7734$19893 = $20336.mem$run;
-                    final PreludeBase.TMaybe<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>> $20338 =
+                    > v7734$19894 = $20337.mem$run;
+                    final PreludeBase.TMaybe<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>> $20339 =
                     RunTM.<Func.U<Global.TGlobal, PreludeBase.TMaybe<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>>>>cast(
-                          v7734$19893
-                        ).apply(v2895$19881.mem2).call();
-                    final PreludeBase.TMaybe.DJust<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>> $20339 =
-                    $20338.asJust();
-                    if ($20339 != null) {
-                      final PreludeBase.TTuple2<QNames.TQName, Global.TGlobal> v2895$19925 =
-                      $20339.mem1.call();
-                      final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols.TSymbolT<Global.TGlobal>> $20341 =
-                      Hover.findSymbol(v2895$19925.mem1);
+                          v7734$19894
+                        ).apply(v2895$19882.mem2).call();
+                    final PreludeBase.TMaybe.DJust<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>> $20340 =
+                    $20339.asJust();
+                    if ($20340 != null) {
+                      final PreludeBase.TTuple2<QNames.TQName, Global.TGlobal> v2895$19926 =
+                      $20340.mem1.call();
+                      final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, Symbols.TSymbolT<Global.TGlobal>> $20342 =
+                      Hover.findSymbol(v2895$19926.mem1);
                       final Func.U<
                         Global.TGlobal,
                         Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>>
-                      > v7734$19937 = $20341.mem$run;
-                      final PreludeBase.TMaybe<PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>> $20343 =
+                      > v7734$19938 = $20342.mem$run;
+                      final PreludeBase.TMaybe<PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>> $20344 =
                       RunTM.<
                         Func.U<
                           Global.TGlobal,
                           PreludeBase.TMaybe<PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>>
                         >
-                      >cast(v7734$19937).apply(v2895$19925.mem2).call();
+                      >cast(v7734$19938).apply(v2895$19926.mem2).call();
                       final PreludeBase.TMaybe.DJust<
                         PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>
-                      > $20344 = $20343.asJust();
-                      if ($20344 != null) {
-                        final PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal> v2895$19969 =
-                        $20344.mem1.call();
-                        final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/*<Character>*/> $20346 =
-                        Hover.getSymbolType(v2895$19969.mem1);
+                      > $20345 = $20344.asJust();
+                      if ($20345 != null) {
+                        final PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal> v2895$19970 =
+                        $20345.mem1.call();
+                        final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, String/*<Character>*/> $20347 =
+                        Hover.getSymbolType(v2895$19970.mem1);
                         final Func.U<
                           Global.TGlobal,
                           Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>>
-                        > v7734$19981 = $20346.mem$run;
-                        final PreludeBase.TMaybe<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>> $20348 =
+                        > v7734$19982 = $20347.mem$run;
+                        final PreludeBase.TMaybe<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>> $20349 =
                         RunTM.<
                           Func.U<Global.TGlobal, PreludeBase.TMaybe<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>>>
-                        >cast(v7734$19981).apply(v2895$19969.mem2).call();
-                        final PreludeBase.TMaybe.DJust<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>> $20349 =
-                        $20348.asJust();
-                        if ($20349 != null) {
-                          final PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal> v2895$20013 =
-                          $20349.mem1.call();
-                          final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover> $20351 =
+                        >cast(v7734$19982).apply(v2895$19970.mem2).call();
+                        final PreludeBase.TMaybe.DJust<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>> $20350 =
+                        $20349.asJust();
+                        if ($20350 != null) {
+                          final PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal> v2895$20014 =
+                          $20350.mem1.call();
+                          final State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover> $20352 =
                           State.IMonad_StateT.<Global.TGlobal, PreludeBase.TMaybe<?>, THover>pure(
                                 Maybe.IMonad_Maybe.it,
                                 THover.mk(
                                       Thunk.<Range.TRange>shared(
                                             (Lazy<Range.TRange>)(() -> Range.tokenToRange(
-                                                      v2895$19881.mem1.call()
+                                                      v2895$19882.mem1.call()
                                                     ))
                                           ),
-                                      v2895$20013.mem1
+                                      v2895$20014.mem1
                                     )
                               );
                           final Func.U<
                             Global.TGlobal, Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>
-                          > v7739$19986 = $20351.mem$run;
+                          > v7739$19987 = $20352.mem$run;
                           return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>>shared(
                                     (Lazy<Kind.U<
                                       PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>
@@ -1397,13 +1397,13 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover>
                                                       Global.TGlobal,
                                                       PreludeBase.TMaybe<PreludeBase.TTuple2<THover, Global.TGlobal>>
                                                     >
-                                                  >cast(v7739$19986).apply(v2895$20013.mem2))
+                                                  >cast(v7739$19987).apply(v2895$20014.mem2))
                                             ).call())
                                   );
                         }
-                        final PreludeBase.TMaybe.DNothing<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>> $20353 =
-                        $20348.asNothing();
-                        assert $20353 != null;
+                        final PreludeBase.TMaybe.DNothing<PreludeBase.TTuple2<String/*<Character>*/, Global.TGlobal>> $20354 =
+                        $20349.asNothing();
+                        assert $20354 != null;
                         return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>>lazy(
                                   (Kind.U<
                                     PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>
@@ -1412,26 +1412,26 @@ final public static State.TStateT<Global.TGlobal, PreludeBase.TMaybe<?>, THover>
                       }
                       final PreludeBase.TMaybe.DNothing<
                         PreludeBase.TTuple2<Symbols.TSymbolT<Global.TGlobal>, Global.TGlobal>
-                      > $20354 = $20343.asNothing();
-                      assert $20354 != null;
+                      > $20355 = $20344.asNothing();
+                      assert $20355 != null;
                       return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>>lazy(
                                 (Kind.U<
                                   PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>
                                 >)PreludeBase.TMaybe.DNothing.<PreludeBase.TTuple2<THover, Global.TGlobal>>mk()
                               );
                     }
-                    final PreludeBase.TMaybe.DNothing<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>> $20355 =
-                    $20338.asNothing();
-                    assert $20355 != null;
+                    final PreludeBase.TMaybe.DNothing<PreludeBase.TTuple2<QNames.TQName, Global.TGlobal>> $20356 =
+                    $20339.asNothing();
+                    assert $20356 != null;
                     return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>>lazy(
                               (Kind.U<
                                 PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>
                               >)PreludeBase.TMaybe.DNothing.<PreludeBase.TTuple2<THover, Global.TGlobal>>mk()
                             );
                   }
-                  final PreludeBase.TMaybe.DNothing<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>> $20356 =
-                  $20333.asNothing();
-                  assert $20356 != null;
+                  final PreludeBase.TMaybe.DNothing<PreludeBase.TTuple2<Tokens.TToken, Global.TGlobal>> $20357 =
+                  $20334.asNothing();
+                  assert $20357 != null;
                   return Thunk.<Kind.U<PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>>>lazy(
                             (Kind.U<
                               PreludeBase.TMaybe<?>, PreludeBase.TTuple2<THover, Global.TGlobal>
@@ -1468,21 +1468,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20357) -> {
-                                            final Global.TGlobal v2056$19442 = CompileGlobal.standardCompileGlobal
-                                            .call().apply(arg$20357).call();
-                                            final Func.U<RealWorld, Global.TGlobal> v2053$19461 =
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20358) -> {
+                                            final Global.TGlobal v2056$19443 = CompileGlobal.standardCompileGlobal
+                                            .call().apply(arg$20358).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$19462 =
                                             CompileExecutor.compile(
                                                   Thunk.<String/*<Character>*/>shared(
                                                         (Lazy<String/*
                                                           <Character>
                                                         */>)(() -> "module HoverTest where\n\n" + "simplyString = \"Hello\"")
                                                       ),
-                                                  v2056$19442
+                                                  v2056$19443
                                                 );
-                                            final Global.TGlobal v2056$19464 = v2053$19461
-                                            .apply(arg$20357).call();
-                                            final Func.U<RealWorld, Boolean> v2057$19465 =
+                                            final Global.TGlobal v2056$19465 = v2053$19462
+                                            .apply(arg$20358).call();
+                                            final Func.U<RealWorld, Boolean> v2057$19466 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Maybe.IEq_Maybe.<
@@ -1528,14 +1528,14 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                         Position.TPosition.mk(
                                                                               Thunk.<Integer>lazy(3), Thunk.<Integer>lazy(3)
                                                                             ),
-                                                                        v2056$19464
+                                                                        v2056$19465
                                                                       )
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19465
-                                                          .apply(arg$20357))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19466
+                                                          .apply(arg$20358))
                                                     );
                                           })
                                     ))
@@ -1556,21 +1556,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20362) -> {
-                                            final Global.TGlobal v2056$19384 = CompileGlobal.standardCompileGlobal
-                                            .call().apply(arg$20362).call();
-                                            final Func.U<RealWorld, Global.TGlobal> v2053$19403 =
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20363) -> {
+                                            final Global.TGlobal v2056$19385 = CompileGlobal.standardCompileGlobal
+                                            .call().apply(arg$20363).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$19404 =
                                             CompileExecutor.compile(
                                                   Thunk.<String/*<Character>*/>shared(
                                                         (Lazy<String/*
                                                           <Character>
                                                         */>)(() -> "module HoverTest where\n\n" + "data MyMaybe a = MyNothing | MyJust a\n")
                                                       ),
-                                                  v2056$19384
+                                                  v2056$19385
                                                 );
-                                            final Global.TGlobal v2056$19406 = v2053$19403
-                                            .apply(arg$20362).call();
-                                            final Func.U<RealWorld, Boolean> v2057$19407 =
+                                            final Global.TGlobal v2056$19407 = v2053$19404
+                                            .apply(arg$20363).call();
+                                            final Func.U<RealWorld, Boolean> v2057$19408 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Maybe.IEq_Maybe.<
@@ -1616,14 +1616,14 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                         Position.TPosition.mk(
                                                                               Thunk.<Integer>lazy(3), Thunk.<Integer>lazy(7)
                                                                             ),
-                                                                        v2056$19406
+                                                                        v2056$19407
                                                                       )
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19407
-                                                          .apply(arg$20362))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19408
+                                                          .apply(arg$20363))
                                                     );
                                           })
                                     ))
@@ -1644,21 +1644,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20367) -> {
-                                            final Global.TGlobal v2056$19326 = CompileGlobal.standardCompileGlobal
-                                            .call().apply(arg$20367).call();
-                                            final Func.U<RealWorld, Global.TGlobal> v2053$19345 =
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20368) -> {
+                                            final Global.TGlobal v2056$19327 = CompileGlobal.standardCompileGlobal
+                                            .call().apply(arg$20368).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$19346 =
                                             CompileExecutor.compile(
                                                   Thunk.<String/*<Character>*/>shared(
                                                         (Lazy<String/*
                                                           <Character>
                                                         */>)(() -> "module HoverTest where\n\n" + ("data MyMaybe a = MyNothing | MyJust a\n" + "res = MyJust 42"))
                                                       ),
-                                                  v2056$19326
+                                                  v2056$19327
                                                 );
-                                            final Global.TGlobal v2056$19348 = v2053$19345
-                                            .apply(arg$20367).call();
-                                            final Func.U<RealWorld, Boolean> v2057$19349 =
+                                            final Global.TGlobal v2056$19349 = v2053$19346
+                                            .apply(arg$20368).call();
+                                            final Func.U<RealWorld, Boolean> v2057$19350 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Maybe.IEq_Maybe.<
@@ -1704,14 +1704,14 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                         Position.TPosition.mk(
                                                                               Thunk.<Integer>lazy(4), Thunk.<Integer>lazy(8)
                                                                             ),
-                                                                        v2056$19348
+                                                                        v2056$19349
                                                                       )
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19349
-                                                          .apply(arg$20367))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19350
+                                                          .apply(arg$20368))
                                                     );
                                           })
                                     ))
@@ -1734,21 +1734,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20372) -> {
-                                            final Global.TGlobal v2056$19616 = CompileGlobal.standardCompileGlobal
-                                            .call().apply(arg$20372).call();
-                                            final Func.U<RealWorld, Global.TGlobal> v2053$19635 =
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20373) -> {
+                                            final Global.TGlobal v2056$19617 = CompileGlobal.standardCompileGlobal
+                                            .call().apply(arg$20373).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$19636 =
                                             CompileExecutor.compile(
                                                   Thunk.<String/*<Character>*/>shared(
                                                         (Lazy<String/*
                                                           <Character>
                                                         */>)(() -> "module HoverTest where\n\n" + "main = println \"Hello\"")
                                                       ),
-                                                  v2056$19616
+                                                  v2056$19617
                                                 );
-                                            final Global.TGlobal v2056$19638 = v2053$19635
-                                            .apply(arg$20372).call();
-                                            final Func.U<RealWorld, Boolean> v2057$19639 =
+                                            final Global.TGlobal v2056$19639 = v2053$19636
+                                            .apply(arg$20373).call();
+                                            final Func.U<RealWorld, Boolean> v2057$19640 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Maybe.IEq_Maybe.<
@@ -1794,14 +1794,14 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                         Position.TPosition.mk(
                                                                               Thunk.<Integer>lazy(3), Thunk.<Integer>lazy(9)
                                                                             ),
-                                                                        v2056$19638
+                                                                        v2056$19639
                                                                       )
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19639
-                                                          .apply(arg$20372))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19640
+                                                          .apply(arg$20373))
                                                     );
                                           })
                                     ))
@@ -1824,21 +1824,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20377) -> {
-                                            final Global.TGlobal v2056$19500 = CompileGlobal.standardCompileGlobal
-                                            .call().apply(arg$20377).call();
-                                            final Func.U<RealWorld, Global.TGlobal> v2053$19519 =
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20378) -> {
+                                            final Global.TGlobal v2056$19501 = CompileGlobal.standardCompileGlobal
+                                            .call().apply(arg$20378).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$19520 =
                                             CompileExecutor.compile(
                                                   Thunk.<String/*<Character>*/>shared(
                                                         (Lazy<String/*
                                                           <Character>
                                                         */>)(() -> "module HoverTest where\n\n" + "import frege.data.Maybe(Maybe)")
                                                       ),
-                                                  v2056$19500
+                                                  v2056$19501
                                                 );
-                                            final Global.TGlobal v2056$19522 = v2053$19519
-                                            .apply(arg$20377).call();
-                                            final Func.U<RealWorld, Boolean> v2057$19523 =
+                                            final Global.TGlobal v2056$19523 = v2053$19520
+                                            .apply(arg$20378).call();
+                                            final Func.U<RealWorld, Boolean> v2057$19524 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Maybe.IEq_Maybe.<
@@ -1884,14 +1884,14 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                         Position.TPosition.mk(
                                                                               Thunk.<Integer>lazy(3), Thunk.<Integer>lazy(27)
                                                                             ),
-                                                                        v2056$19522
+                                                                        v2056$19523
                                                                       )
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19523
-                                                          .apply(arg$20377))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19524
+                                                          .apply(arg$20378))
                                                     );
                                           })
                                     ))
@@ -1914,21 +1914,21 @@ final public static Lazy<QuickCheckGen.TGen<
                               QuickCheckProperty.TRose<QuickCheckProperty.TResult>
                             >>)(() -> QuickCheckProperty.<Boolean>morallyDubiousIOProperty(
                                       QuickCheckProperty.ITestable_Bool.it,
-                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20382) -> {
-                                            final Global.TGlobal v2056$19558 = CompileGlobal.standardCompileGlobal
-                                            .call().apply(arg$20382).call();
-                                            final Func.U<RealWorld, Global.TGlobal> v2053$19577 =
+                                      (Func.U<RealWorld, Boolean>)((final Lazy<RealWorld> arg$20383) -> {
+                                            final Global.TGlobal v2056$19559 = CompileGlobal.standardCompileGlobal
+                                            .call().apply(arg$20383).call();
+                                            final Func.U<RealWorld, Global.TGlobal> v2053$19578 =
                                             CompileExecutor.compile(
                                                   Thunk.<String/*<Character>*/>shared(
                                                         (Lazy<String/*
                                                           <Character>
                                                         */>)(() -> "module HoverTest where\n\n" + ("import frege.data.Maybe(Maybe, Just)\n" + "res = Just 42"))
                                                       ),
-                                                  v2056$19558
+                                                  v2056$19559
                                                 );
-                                            final Global.TGlobal v2056$19580 = v2053$19577
-                                            .apply(arg$20382).call();
-                                            final Func.U<RealWorld, Boolean> v2057$19581 =
+                                            final Global.TGlobal v2056$19581 = v2053$19578
+                                            .apply(arg$20383).call();
+                                            final Func.U<RealWorld, Boolean> v2057$19582 =
                                             PreludeMonad.IMonad_ST.<RealWorld, Boolean>pure(
                                                   Thunk.<Boolean>shared(
                                                         (Lazy<Boolean>)(() -> Maybe.IEq_Maybe.<
@@ -1974,14 +1974,14 @@ final public static Lazy<QuickCheckGen.TGen<
                                                                         Position.TPosition.mk(
                                                                               Thunk.<Integer>lazy(4), Thunk.<Integer>lazy(10)
                                                                             ),
-                                                                        v2056$19580
+                                                                        v2056$19581
                                                                       )
                                                                 ))
                                                       )
                                                 );
                                             return Thunk.<Boolean>nested(
-                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19581
-                                                          .apply(arg$20382))
+                                                      (Lazy<Lazy<Boolean>>)(() -> v2057$19582
+                                                          .apply(arg$20383))
                                                     );
                                           })
                                     ))
@@ -1991,27 +1991,27 @@ final public static Lazy<QuickCheckGen.TGen<
     );
 final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWorld, Short>>shared(
       (Lazy<Func.U<RealWorld, Short>>)(() -> {
-            return (Func.U<RealWorld, Short>)((final Lazy<RealWorld> arg$20387) -> {
-                      final Global.TGlobal v2056$19667 = CompileGlobal.standardCompileGlobal
-                      .call().apply(arg$20387).call();
-                      final Func.U<RealWorld, Global.TGlobal> v2053$19686 = CompileExecutor.compile(
+            return (Func.U<RealWorld, Short>)((final Lazy<RealWorld> arg$20388) -> {
+                      final Global.TGlobal v2056$19668 = CompileGlobal.standardCompileGlobal
+                      .call().apply(arg$20388).call();
+                      final Func.U<RealWorld, Global.TGlobal> v2053$19687 = CompileExecutor.compile(
                             Thunk.<String/*<Character>*/>shared(
                                   (Lazy<String/*
                                     <Character>
                                   */>)(() -> "module HoverTest where\n\n" + ("import frege.compiler.Main(runpass)\n\n" + ("pass = runpass\n" + ("me = 42\n\n" + "main = do\n  a = \"Hello\"\n  println a"))))
                                 ),
-                            v2056$19667
+                            v2056$19668
                           );
-                      final Global.TGlobal v2056$19689 = v2053$19686.apply(arg$20387)
+                      final Global.TGlobal v2056$19690 = v2053$19687.apply(arg$20388)
                       .call();
-                      final Func.U<RealWorld, Short> v4793$19711 = Prelude.<String/*<Character>*/>println(
-                            PreludeText.IShow_String.it, Global.TSubSt.code(Global.TGlobal.sub(v2056$19689)).toString()
+                      final Func.U<RealWorld, Short> v4793$19712 = Prelude.<String/*<Character>*/>println(
+                            PreludeText.IShow_String.it, Global.TSubSt.code(Global.TGlobal.sub(v2056$19690)).toString()
                           );
-                      final short v4796$19713 = (short)v4793$19711.apply(arg$20387).call();
-                      final Func.U<RealWorld, Short> v4797$19714 = ((Func.U<RealWorld, Short>)((
-                        final Lazy<RealWorld> arg$20395
+                      final short v4796$19714 = (short)v4793$19712.apply(arg$20388).call();
+                      final Func.U<RealWorld, Short> v4797$19715 = ((Func.U<RealWorld, Short>)((
+                        final Lazy<RealWorld> arg$20396
                       ) -> {
-                            final short v4796$19744 = (short)Func.<RealWorld, Short>coerceU(
+                            final short v4796$19745 = (short)Func.<RealWorld, Short>coerceU(
                                   PreludeMonad.<Func.U<RealWorld, ?>, Tokens.TToken, Short, PreludeBase.TList<?>>$for(
                                         PreludeMonad.IMonad_ST.<RealWorld>mk(),
                                         PreludeList.IListSource_$lbrack$rbrack.<PreludeBase.TList<?>>mk(),
@@ -2022,44 +2022,44 @@ final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWor
                                                         (Lazy<PreludeBase.TList<
                                                           Tokens.TToken
                                                         >>)(() -> Tokens.IArrayElement_Token.listFromArray(
-                                                                  Global.TSubSt.toks(Global.TGlobal.sub(v2056$19689))
+                                                                  Global.TSubSt.toks(Global.TGlobal.sub(v2056$19690))
                                                                 ))
                                                       ).call())
                                             ),
                                         (Func.U<Tokens.TToken, Kind.U<Func.U<RealWorld, ?>, Short>>)((
-                                          final Lazy<Tokens.TToken> η$20394
+                                          final Lazy<Tokens.TToken> η$20395
                                         ) -> Thunk.<Kind.U<Func.U<RealWorld, ?>, Short>>shared(
                                                   (Lazy<Kind.U<Func.U<RealWorld, ?>, Short>>)(() -> (Kind.U<
                                                         Func.U<RealWorld, ?>, Short
                                                       >)Thunk.<Func.U<RealWorld, Short>>shared(
                                                             (Lazy<Func.U<RealWorld, Short>>)(() -> Prelude.<
                                                                   Tokens.TToken
-                                                                >println(Tokens.IShow_Token.it, η$20394.call()))
+                                                                >println(Tokens.IShow_Token.it, η$20395.call()))
                                                           ).call())
                                                 ))
                                       )
-                                ).apply(arg$20395).call();
-                            final Func.U<RealWorld, Short> v4797$19745 = ((Func.U<RealWorld, Short>)((
-                              final Lazy<RealWorld> arg$20391
+                                ).apply(arg$20396).call();
+                            final Func.U<RealWorld, Short> v4797$19746 = ((Func.U<RealWorld, Short>)((
+                              final Lazy<RealWorld> arg$20392
                             ) -> {
-                                  final short v4796$19768 = (short)Prelude.<PreludeBase.TMaybe<THover>>println(
+                                  final short v4796$19769 = (short)Prelude.<PreludeBase.TMaybe<THover>>println(
                                         new PreludeText.IShow_Maybe<THover>(IShow_Hover.it),
                                         Hover.getTypeSignatureOnHover(
-                                              Position.TPosition.mk(Thunk.<Integer>lazy(5), Thunk.<Integer>lazy(9)), v2056$19689
+                                              Position.TPosition.mk(Thunk.<Integer>lazy(5), Thunk.<Integer>lazy(9)), v2056$19690
                                             )
-                                      ).apply(arg$20391).call();
-                                  final Func.U<RealWorld, Short> v4797$19769 = Thunk.<
+                                      ).apply(arg$20392).call();
+                                  final Func.U<RealWorld, Short> v4797$19770 = Thunk.<
                                     Func.U<RealWorld, Short>
                                   >shared(
                                         (Lazy<Func.U<RealWorld, Short>>)(() -> Prelude.<
                                               String/*<Character>*/
                                             >println(PreludeText.IShow_String.it, "end"))
                                       ).call();
-                                  return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$19769.apply(arg$20391)));
+                                  return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$19770.apply(arg$20392)));
                                 })).call();
-                            return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$19745.apply(arg$20395)));
+                            return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$19746.apply(arg$20396)));
                           })).call();
-                      return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$19714.apply(arg$20387)));
+                      return Thunk.<Short>nested((Lazy<Lazy<Short>>)(() -> v4797$19715.apply(arg$20388)));
                     });
           })
     );

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/HoverLSP.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/hover/HoverLSP.java
@@ -156,7 +156,7 @@ import frege.test.QuickCheckText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/HoverLSP.fr",
-  time=1659200054265L, jmajor=11, jminor=-1,
+  time=1659433741764L, jmajor=11, jminor=-1,
   imps={
     "frege.compiler.types.Global", "ch.fhnw.thga.fregelanguageserver.hover.Hover",
     "ch.fhnw.thga.fregelanguageserver.lsp4j.PositionLSP4J", "frege.Prelude", "frege.prelude.PreludeArrays",
@@ -299,13 +299,13 @@ final public class HoverLSP  {
 
 final public static class THoverLSP  {
   final public static org.eclipse.lsp4j.Hover fromHover(final Hover.THover arg$1) {
-    final String/*<Character>*/ content$18105 = arg$1.mem$content.call();
-    final Range.TRange range$18104 = arg$1.mem$range.call();
+    final String/*<Character>*/ content$18106 = arg$1.mem$content.call();
+    final Range.TRange range$18105 = arg$1.mem$range.call();
     return new org.eclipse.lsp4j.Hover(
           new org.eclipse.lsp4j.MarkupContent(
-            org.eclipse.lsp4j.MarkupKind.MARKDOWN, Hover.IShow_FregeCodeBlock.show(content$18105)
+            org.eclipse.lsp4j.MarkupKind.MARKDOWN, Hover.IShow_FregeCodeBlock.show(content$18106)
           ),
-          RangeLSP4J.TRangeLSP.fromRange(range$18104)
+          RangeLSP4J.TRangeLSP.fromRange(range$18105)
         );
   }
 }
@@ -317,19 +317,19 @@ final public static Lazy<Func.U<RealWorld, Short>> $main = Thunk.<Func.U<RealWor
 final public static PreludeBase.TMaybe<org.eclipse.lsp4j.Hover> getTypeSignatureOnHoverLSP(
   final Lazy<org.eclipse.lsp4j.Position> arg$1, final Lazy<Global.TGlobal> arg$2
 ) {
-  final PreludeBase.TMaybe<Hover.THover> $18156 = Hover.getTypeSignatureOnHover(
+  final PreludeBase.TMaybe<Hover.THover> $18157 = Hover.getTypeSignatureOnHover(
         Thunk.<Position.TPosition>shared((Lazy<Position.TPosition>)(() -> PositionLSP4J.TPositionLSP.toPosition(arg$1))), arg$2
       );
-  final PreludeBase.TMaybe.DJust<Hover.THover> $18157 = $18156.asJust();
-  if ($18157 != null) {
+  final PreludeBase.TMaybe.DJust<Hover.THover> $18158 = $18157.asJust();
+  if ($18158 != null) {
     return Maybe.IApplicative_Maybe.<org.eclipse.lsp4j.Hover>pure(
               Thunk.<org.eclipse.lsp4j.Hover>shared(
-                    (Lazy<org.eclipse.lsp4j.Hover>)(() -> THoverLSP.fromHover($18157.mem1.call()))
+                    (Lazy<org.eclipse.lsp4j.Hover>)(() -> THoverLSP.fromHover($18158.mem1.call()))
                   )
             );
   }
-  final PreludeBase.TMaybe.DNothing<Hover.THover> $18158 = $18156.asNothing();
-  assert $18158 != null;
+  final PreludeBase.TMaybe.DNothing<Hover.THover> $18159 = $18157.asNothing();
+  assert $18159 != null;
   return PreludeBase.TMaybe.DNothing.<org.eclipse.lsp4j.Hover>mk();
 }
 

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/lsp4j/PositionLSP4J.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/lsp4j/PositionLSP4J.java
@@ -36,7 +36,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/lsp4j/PositionLSP4J.fr",
-  time=1659200052339L, jmajor=11, jminor=-1,
+  time=1659433739734L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.types.Position", "frege.Prelude", "frege.prelude.PreludeArrays",
     "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal", "frege.prelude.PreludeIO", "frege.prelude.PreludeList",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/lsp4j/RangeLSP4J.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/lsp4j/RangeLSP4J.java
@@ -40,7 +40,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/lsp4j/RangeLSP4J.fr",
-  time=1659200052624L, jmajor=11, jminor=-1,
+  time=1659433740058L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.lsp4j.PositionLSP4J", "frege.Prelude", "frege.prelude.PreludeArrays",
     "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal", "frege.prelude.PreludeIO", "frege.prelude.PreludeList",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/types/Position.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/types/Position.java
@@ -34,7 +34,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/types/Position.fr",
-  time=1659200051387L, jmajor=11, jminor=-1,
+  time=1659433738985L, jmajor=11, jminor=-1,
   imps={
     "frege.Prelude", "frege.prelude.PreludeArrays", "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal",
     "frege.prelude.PreludeIO", "frege.prelude.PreludeList", "frege.prelude.PreludeMonad", "frege.prelude.PreludeText",

--- a/src/main/java/ch/fhnw/thga/fregelanguageserver/types/Range.java
+++ b/src/main/java/ch/fhnw/thga/fregelanguageserver/types/Range.java
@@ -37,7 +37,7 @@ import frege.prelude.PreludeText;
 @SuppressWarnings("unused")
 @Meta.FregePackage(
   source="/Users/tricktron/github/master/frege-lsp-server/src/main/frege/ch/fhnw/thga/fregelanguageserver/types/Range.fr",
-  time=1659200052366L, jmajor=11, jminor=-1,
+  time=1659433739754L, jmajor=11, jminor=-1,
   imps={
     "ch.fhnw.thga.fregelanguageserver.types.Position", "frege.Prelude", "frege.prelude.PreludeArrays",
     "frege.prelude.PreludeBase", "frege.prelude.PreludeDecimal", "frege.prelude.PreludeIO", "frege.prelude.PreludeList",


### PR DESCRIPTION
Implements the workaround for #29.

Local frege imports are resolved with .class files on the classpath. For this we need to compile the frege files to java first and then run the java compiler to compile to .class files.

However, since make mode is not yet completely implemented, the imports are not resolved interactively. As a result, you may have to restart the language server completely if you change the dependency of a module.