### PR TITLE
Replace StateT with Reader

### DIFF
--- a/docs/modules/ROOT/pages/code.adoc
+++ b/docs/modules/ROOT/pages/code.adoc
@@ -131,20 +131,20 @@ The `getTypeOnHover` function is responsible for the main work and is shown in <
 .The `getTypeOnHover` Function
 [source#code-getTypeOnHover,haskell]
 ----
-getTypeOnHover :: Position -> MaybeT RGlobal Hover // <1>
-getTypeOnHover pos = do
-    token      <- findToken pos // <2>
-    qname      <- tokenToQName token // <2>
-    symbol     <- findSymbol qname // <2>
-    symbolType <- lift $ getSymbolType symbol // <2>
-    pure        $ Hover // <3>
+getTypeOnHover :: Global -> Position -> Maybe Hover // <1>
+getTypeOnHover global pos = do
+    token      <- findToken global pos // <2>
+    qname      <- tokenToQName global token // <2>
+    symbol     <- findSymbol global qname // <2>
+    symbolType  = getSymbolType global symbol // <2>
+    pure        $ Hover // <3> 
         { 
             range   = tokenToRange token, 
             content = FregeCodeBlock symbolType
         }
 ----
-<1> The function uses the monad transformer concept to combine the `Maybe Hover` (to account for no available type signature) and the `Reader Global` (the read-only `Global` record from the impure input phase) monads.
-<2> The main logic: We find the needed type in the big `Global` record by moving from `token -> qualifiedName -> symbol -> symbolType`.
+<1> The function uses the `Maybe` monad to account for no available type signature.
+<2> The main logic: We find the needed type in the big `Global` record by moving from `token -> qualified name -> symbol -> symbolType`.
 <3> As a last step, we transform the result to our core data type `Hover`.
 
 Since the core is pure and since we developed it with a xref:principles.adoc#_test_driven_development[Test-Driven Development] approach it is testable as shown in <<code-hover-test>>.

--- a/docs/modules/ROOT/pages/code.adoc
+++ b/docs/modules/ROOT/pages/code.adoc
@@ -126,29 +126,28 @@ seqdiag {
 }
 ....
 
-The `getTypeOnHover` function is responsible for the main work and shown in <<code-getTypeOnHover>>.
+The `getTypeOnHover` function is responsible for the main work and is shown in <<code-getTypeOnHover>>.
 
 .The `getTypeOnHover` Function
 [source#code-getTypeOnHover,haskell]
 ----
-getTypeOnHover :: Position -> StateT Global Maybe Hover // <1>
+getTypeOnHover :: Position -> MaybeT RGlobal Hover // <1>
 getTypeOnHover pos = do
-    global     <- StateT.get
-    token      <- findToken pos <2>
-    qname      <- tokenToQName token <2>
-    symbol     <- findSymbol qname <2>
-    symbolType <- getSymbolType symbol <2>
-    pure        $ Hover <3>
+    token      <- findToken pos // <2>
+    qname      <- tokenToQName token // <2>
+    symbol     <- findSymbol qname // <2>
+    symbolType <- lift $ getSymbolType symbol // <2>
+    pure        $ Hover // <3>
         { 
             range   = tokenToRange token, 
             content = FregeCodeBlock symbolType
         }
 ----
-<1> The function uses the monad transformer concept to combine the `State Global` and the `Maybe Hover` monad.
-<2> The main logicWe find the needed type in the big `Global` record by moving from `token -> qualifiedName -> symbol -> symbolType`.
+<1> The function uses the monad transformer concept to combine the `Maybe Hover` (to account for no available type signature) and the `Reader Global` (the read-only `Global` record from the impure input phase) monads.
+<2> The main logic: We find the needed type in the big `Global` record by moving from `token -> qualifiedName -> symbol -> symbolType`.
 <3> As a last step, we transform the result to our core data type `Hover`.
 
-Since the core is pure and since we developed it with a xref:principles.adoc#_test_driven_development[Test-Driven Development] approach it is testable as shown <<code-hover-test>>.
+Since the core is pure and since we developed it with a xref:principles.adoc#_test_driven_development[Test-Driven Development] approach it is testable as shown in <<code-hover-test>>.
 
 .A Hover test case checking the type signature of a string constant
 [source#code-hover-test,haskell]

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version       = 4.1.4-alpha
+version       = 4.1.5-alpha
 gradleVersion = 7.4.2

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.fr
@@ -8,7 +8,9 @@ import Compiler.types.Global(StG, StIO, Message, Global, Severity(), tokens, get
 import Compiler.types.Tokens(Token)
 import frege.compiler.types.Positions (Position TokenPosition)
 import Test.QuickCheck (Property, once, morallyDubiousIOProperty)
-import Control.monad.State (evalStateT, execStateT, evalState)
+import frege.Prelude hiding (Reader)
+import Control.monad.Reader(Reader, ask)
+import frege.data.wrapper.Identity(Identity)
 
 data DiagnosticSeverity = ERROR | WARNING | INFORMATION | HINT
 
@@ -44,13 +46,13 @@ tokensToRange tks    =
         end   = Position endToken.line (endToken.col + (length endToken.value))  
     }
 
-createRangeFromPos :: TokenPosition -> StG Range
+createRangeFromPos :: TokenPosition -> Reader Global Range
 createRangeFromPos pos = do
-    gl  <- getST
+    gl  <- ask
     toks = tokens pos gl
     pure $ tokensToRange toks
 
-createDiagnosticFromMessage :: Message -> StG Diagnostic
+createDiagnosticFromMessage :: Message -> Reader Global Diagnostic
 createDiagnosticFromMessage message = do
     range <- createRangeFromPos message.pos
     pure   $ Diagnostic 
@@ -61,14 +63,14 @@ createDiagnosticFromMessage message = do
             message = message.text
         }
 
-extractDiagnostics :: StG [ Diagnostic ]
+extractDiagnostics :: Reader Global [ Diagnostic ]
 extractDiagnostics = do
-    gl         <- getST
+    gl         <- ask
     diagnostics = fmap createDiagnosticFromMessage gl.sub.messages
     sequence diagnostics
 
 getDiagnostics :: Global -> [ Diagnostic ]
-getDiagnostics = evalState $ extractDiagnostics
+getDiagnostics gl = Identity.run $ Reader.run (extractDiagnostics) gl
 
 fregeLSPServerShouldMapNoCompilerMessagesToEmptyArray :: Property
 fregeLSPServerShouldMapNoCompilerMessagesToEmptyArray = once $ morallyDubiousIOProperty do

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.fr
@@ -8,9 +8,6 @@ import Compiler.types.Global(Global, Message, Severity(), tokens)
 import Compiler.types.Tokens(Token)
 import frege.compiler.types.Positions (Position TokenPosition)
 import Test.QuickCheck (Property, once, morallyDubiousIOProperty)
-import frege.Prelude hiding (Reader)
-import Control.monad.Reader(Reader, ask)
-import frege.data.wrapper.Identity(Identity)
 
 data DiagnosticSeverity = ERROR | WARNING | INFORMATION | HINT
 
@@ -46,16 +43,15 @@ tokensToRange tks    =
         end   = Position endToken.line (endToken.col + (length endToken.value))  
     }
 
-createRangeFromPos :: TokenPosition -> Reader Global Range
-createRangeFromPos pos = do
-    gl  <- ask
-    toks = tokens pos gl
-    pure $ tokensToRange toks
+createRangeFromPos :: Global -> TokenPosition -> Range
+createRangeFromPos global pos = do
+    toks = tokens pos global
+    tokensToRange toks
 
-createDiagnosticFromMessage :: Message -> Reader Global Diagnostic
-createDiagnosticFromMessage message = do
-    range <- createRangeFromPos message.pos
-    pure   $ Diagnostic 
+createDiagnosticFromMessage :: Global -> Message -> Diagnostic
+createDiagnosticFromMessage global message = do
+    range = createRangeFromPos global message.pos
+    Diagnostic 
         {
             range = range,
             severity = fromCompilerSeverity message.level, 
@@ -63,14 +59,11 @@ createDiagnosticFromMessage message = do
             message = message.text
         }
 
-extractDiagnostics :: Reader Global [ Diagnostic ]
-extractDiagnostics = do
-    gl         <- ask
-    diagnostics = fmap createDiagnosticFromMessage gl.sub.messages
-    sequence diagnostics
+extractDiagnostics :: Global -> [ Diagnostic ]
+extractDiagnostics global = map (createDiagnosticFromMessage global) global.sub.messages
 
 getDiagnostics :: Global -> [ Diagnostic ]
-getDiagnostics = Identity.run . Reader.run (extractDiagnostics)
+getDiagnostics = extractDiagnostics
 
 fregeLSPServerShouldMapNoCompilerMessagesToEmptyArray :: Property
 fregeLSPServerShouldMapNoCompilerMessagesToEmptyArray = once $ morallyDubiousIOProperty do
@@ -93,7 +86,8 @@ fregeLSPServerShouldMapSingleCompilerMessageToDiagnostics = once $ morallyDubiou
                 range    = Range { start = Position 3 8, end = Position 3 22 }, 
                 severity = ERROR, 
                 source   = "frege compiler", 
-                message  = "Could not import module frege.does.not.Exist\n(java.lang.ClassNotFoundException: frege.does.not.Exist)" 
+                message  = "Could not import module frege.does.not.Exist\n"
+                        ++ "(java.lang.ClassNotFoundException: frege.does.not.Exist)" 
             } 
         ]
     actual  = getDiagnostics compiledGlobal
@@ -101,7 +95,11 @@ fregeLSPServerShouldMapSingleCompilerMessageToDiagnostics = once $ morallyDubiou
 
 fregeLSPServerShouldMapMultipleCompilerMessageToDiagnostics :: Property
 fregeLSPServerShouldMapMultipleCompilerMessageToDiagnostics = once $ morallyDubiousIOProperty do
-    fregeCodeWithErrors = "module ch.fhnw.thga.FaultyFregeTest where\n\nerr1 = do\n  x = 42\n\nerr2 = [ 22.0 ] ++ \"42\"\n\nerr3 = 42 + \"42\""
+    fregeCodeWithErrors = "module ch.fhnw.thga.FaultyFregeTest where\n\n"
+                       ++ "err1 = do\n"
+                       ++ "  x = 42\n\n"
+                       ++ "err2 = [ 22.0 ] ++ \"42\"\n\n"
+                       ++ "err3 = 42 + \"42\""
     global             <- standardCompileGlobal
     compiledGlobal     <- compile fregeCodeWithErrors global 
     expected            = 

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.fr
@@ -44,20 +44,20 @@ tokensToRange tks    =
     }
 
 createRangeFromPos :: Global -> TokenPosition -> Range
-createRangeFromPos global pos = do
-    toks = tokens pos global
+createRangeFromPos global pos =
+    let
+        toks = tokens pos global
+    in
     tokensToRange toks
 
 createDiagnosticFromMessage :: Global -> Message -> Diagnostic
-createDiagnosticFromMessage global message = do
-    range = createRangeFromPos global message.pos
-    Diagnostic 
-        {
-            range = range,
-            severity = fromCompilerSeverity message.level, 
-            source = "frege compiler", 
-            message = message.text
-        }
+createDiagnosticFromMessage global message = Diagnostic 
+    {
+        range    = createRangeFromPos global message.pos,
+        severity = fromCompilerSeverity message.level, 
+        source   = "frege compiler", 
+        message  = message.text
+    }
 
 extractDiagnostics :: Global -> [ Diagnostic ]
 extractDiagnostics global = map (createDiagnosticFromMessage global) global.sub.messages
@@ -135,8 +135,14 @@ posToTokens (p:ps) gl = tokens p gl ++ posToTokens ps gl
 
 main :: IO ()
 main = do
-    let fregeCode       = "module ch.fhnw.thga.FaultyFregeTest where\n\nerr1 = do\n  x = 42\n\nerr2 = [ 22.0 ] ++ \"42\"\n\nerr3 = 42 + \"42\"\n\n"
-    let trickyFregeCode = "module FaultyFregeTest where\n\nsimplyString s = s\n\nerr1 = (simplyString 42) ++ \"test\""
+    let fregeCode       = "module ch.fhnw.thga.FaultyFregeTest where\n\n"
+                       ++ "err1 = do\n"
+                       ++ "  x = 42\n\n"
+                       ++ "err2 = [ 22.0 ] ++ \"42\"\n\n"
+                       ++ "err3 = 42 + \"42\""
+    let trickyFregeCode = "module FaultyFregeTest where\n\n"
+                       ++ "simplyString s = s\n\n"
+                       ++ "err1 = (simplyString 42) ++ \"test\""
     global             <- standardCompileGlobal 
     gl                 <- compile trickyFregeCode global
     println             $ CharSequence.toString gl.sub.code

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.fr
@@ -70,7 +70,7 @@ extractDiagnostics = do
     sequence diagnostics
 
 getDiagnostics :: Global -> [ Diagnostic ]
-getDiagnostics gl = Identity.run $ Reader.run (extractDiagnostics) gl
+getDiagnostics = Identity.run . Reader.run (extractDiagnostics)
 
 fregeLSPServerShouldMapNoCompilerMessagesToEmptyArray :: Property
 fregeLSPServerShouldMapNoCompilerMessagesToEmptyArray = once $ morallyDubiousIOProperty do

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/diagnostic/Diagnostic.fr
@@ -4,7 +4,7 @@ import ch.fhnw.thga.fregelanguageserver.compile.CompileGlobal(standardCompileGlo
 import ch.fhnw.thga.fregelanguageserver.compile.CompileNormalMode(compile)
 import ch.fhnw.thga.fregelanguageserver.types.Position(Position)
 import ch.fhnw.thga.fregelanguageserver.types.Range(Range, tokenToRange)
-import Compiler.types.Global(StG, StIO, Message, Global, Severity(), tokens, getST, liftStG, liftIO)
+import Compiler.types.Global(Global, Message, Severity(), tokens)
 import Compiler.types.Tokens(Token)
 import frege.compiler.types.Positions (Position TokenPosition)
 import Test.QuickCheck (Property, once, morallyDubiousIOProperty)

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr
@@ -11,15 +11,20 @@ import Compiler.types.Global(
     )
 import Compiler.types.Tokens(Token)
 import Test.QuickCheck(Property, once, morallyDubiousIOProperty)
-import Control.monad.State(StateT, evalStateT, execStateT, evalState)
+import Control.monad.Reader(ReaderT)
 import Control.monad.trans.MonadTrans (lift)
+import Control.monad.trans.MaybeT (MaybeT)
 import frege.ide.Utilities(label)
 import Data.List(find, sortBy)
 import Compiler.types.QNames(QName)
+import Control.arrow.Kleisli(Kleisli)
+import frege.data.wrapper.Identity(Identity)
 
 newtype FregeCodeBlock = FregeCodeBlock {
     code :: String
 }
+
+type RGlobal = Kleisli Identity Global
 
 derive Eq FregeCodeBlock
 instance Show FregeCodeBlock where
@@ -34,44 +39,47 @@ data Hover = Hover {
 derive Eq Hover
 derive Show Hover
 
-getSymbolType:: Symbol -> StateT Global Maybe String
+getSymbolType:: Symbol -> RGlobal String
 getSymbolType sym = do
-    global <- StateT.get
-    pure   $ label global sym
+    global <- Reader.ask
+    pure    $ label global sym
 
-findToken :: Position -> StateT Global Maybe Token
-findToken pos = do
-    global <- StateT.get
-    tokens = listFromArray global.sub.toks
-    lift   $ find isHoverOverToken tokens where
+findToken :: Position -> MaybeT RGlobal Token
+findToken pos = MaybeT $ do
+    global <- Reader.ask
+    tokens  = listFromArray global.sub.toks
+    pure    $ find isHoverOverToken tokens where
         isHoverOverToken :: Token -> Bool
         isHoverOverToken t = 
             pos.line      == t.line && 
             pos.character  < (t.col + (length t.value)) &&
             pos.character >= t.col
 
-findSymbol :: QName -> StateT Global Maybe Symbol
-findSymbol qname = do
-    global  <- StateT.get
-    lift     $ Global.find global qname
+findSymbol :: QName -> MaybeT RGlobal Symbol
+findSymbol qname = MaybeT $ do
+    global  <- Reader.ask
+    pure     $ Global.find global qname
 
-tokenToQName :: Token -> StateT Global Maybe QName
-tokenToQName t = do
-    global              <- StateT.get
-    namespaceOrVariable <- lift $ Global.resolved global t
-    lift                 $ either (const Nothing) Just namespaceOrVariable
+tokenToQName :: Token -> MaybeT RGlobal QName
+tokenToQName t = MaybeT do
+    global   <- Reader.ask
+    resolved  = Global.resolved global t
+    case resolved of
+        Nothing -> pure Nothing
+        (Just namespaceOrVariable) -> pure $ either (const Nothing) Just namespaceOrVariable
 
 getTypeSignatureOnHover :: Position -> Global -> Maybe Hover
-getTypeSignatureOnHover pos = evalStateT $ getTypeOnHover pos
+getTypeSignatureOnHover pos global = res where
+    readerAction = MaybeT.run $ getTypeOnHover pos
+    res          = Identity.run $ ReaderT.run readerAction global
 
-getTypeOnHover :: Position -> StateT Global Maybe Hover
+getTypeOnHover :: Position -> MaybeT RGlobal Hover
 getTypeOnHover pos = do
-    global     <- StateT.get
     token      <- findToken pos
     qname      <- tokenToQName token
     symbol     <- findSymbol qname
-    symbolType <- getSymbolType symbol
-    pure        $ Hover 
+    symbolType <- lift $ getSymbolType symbol
+    pure $ Hover 
         { 
             range   = tokenToRange token, 
             content = FregeCodeBlock symbolType

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr
@@ -34,8 +34,10 @@ getSymbolType:: Global -> Symbol -> String
 getSymbolType = label
 
 findToken :: Global -> Position -> Maybe Token
-findToken global pos = do
-    tokens = listFromArray global.sub.toks
+findToken global pos =
+    let 
+        tokens = listFromArray global.sub.toks
+    in
     find isHoverOverToken tokens where
         isHoverOverToken :: Token -> Bool
         isHoverOverToken t = 
@@ -48,8 +50,8 @@ findSymbol = Global.find
 
 tokenToQName :: Global -> Token -> Maybe QName
 tokenToQName global token = do
-    namespaceOrVariable <- Global.resolved global token
-    either (const Nothing) Just namespaceOrVariable
+    Right namespaceOrVariable <- Global.resolved global token
+    pure  namespaceOrVariable
 
 getTypeSignatureOnHover :: Position -> Global -> Maybe Hover
 getTypeSignatureOnHover = flip getTypeOnHover

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr
@@ -39,6 +39,9 @@ data Hover = Hover {
 derive Eq Hover
 derive Show Hover
 
+liftMaybe :: MonadPlus m => Maybe a -> m a
+liftMaybe = maybe mzero return
+
 getSymbolType:: Symbol -> RGlobal String
 getSymbolType sym = do
     global <- Reader.ask
@@ -61,12 +64,10 @@ findSymbol qname = MaybeT $ do
     pure     $ Global.find global qname
 
 tokenToQName :: Token -> MaybeT RGlobal QName
-tokenToQName t = MaybeT do
-    global   <- Reader.ask
-    resolved  = Global.resolved global t
-    case resolved of
-        Nothing -> pure Nothing
-        (Just namespaceOrVariable) -> pure $ either (const Nothing) Just namespaceOrVariable
+tokenToQName t = do
+    global   <- lift $ Reader.ask
+    resolved <- liftMaybe $ Global.resolved global t
+    liftMaybe $ either (const empty) Just resolved
 
 getTypeSignatureOnHover :: Position -> Global -> Maybe Hover
 getTypeSignatureOnHover pos global = res where

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr
@@ -8,75 +8,58 @@ import ch.fhnw.thga.fregelanguageserver.types.Range(Range, tokenToRange)
 import Compiler.types.Global(Global, Symbol)
 import Compiler.types.Tokens(Token)
 import Test.QuickCheck(Property, once, morallyDubiousIOProperty)
-import Control.monad.Reader(ReaderT, ask)
-import Control.monad.trans.MonadTrans (lift)
-import Control.monad.trans.MaybeT (MaybeT)
 import frege.ide.Utilities(label)
 import Data.List(find)
 import Compiler.types.QNames(QName)
-import Control.arrow.Kleisli(Kleisli)
-import frege.data.wrapper.Identity(Identity)
 
-newtype FregeCodeBlock = FregeCodeBlock {
-    code :: String
-}
-
-type RGlobal = Kleisli Identity Global
-
+newtype FregeCodeBlock = FregeCodeBlock 
+    {
+        code :: String
+    }
 derive Eq FregeCodeBlock
+
 instance Show FregeCodeBlock where
     show FregeCodeBlock { code } = 
         "```frege\n" ++ code ++ "\n```"
 
-data Hover = Hover {
-    range   :: Range,
-    content :: FregeCodeBlock
-}
-
+data Hover = Hover 
+    {
+        range   :: Range,
+        content :: FregeCodeBlock
+    }
 derive Eq Hover
 derive Show Hover
 
-liftMaybe :: MonadPlus m => Maybe a -> m a
-liftMaybe = maybe mzero return
+getSymbolType:: Global -> Symbol -> String
+getSymbolType = label
 
-getSymbolType:: Symbol -> RGlobal String
-getSymbolType sym = do
-    global <- ask
-    pure    $ label global sym
-
-findToken :: Position -> MaybeT RGlobal Token
-findToken pos = MaybeT $ do
-    global <- ask
-    tokens  = listFromArray global.sub.toks
-    pure    $ find isHoverOverToken tokens where
+findToken :: Global -> Position -> Maybe Token
+findToken global pos = do
+    tokens = listFromArray global.sub.toks
+    find isHoverOverToken tokens where
         isHoverOverToken :: Token -> Bool
         isHoverOverToken t = 
             pos.line      == t.line && 
             pos.character  < (t.col + (length t.value)) &&
             pos.character >= t.col
 
-findSymbol :: QName -> MaybeT RGlobal Symbol
-findSymbol qname = MaybeT $ do
-    global  <- ask
-    pure     $ Global.find global qname
+findSymbol :: Global -> QName -> Maybe Symbol
+findSymbol = Global.find
 
-tokenToQName :: Token -> MaybeT RGlobal QName
-tokenToQName t = do
-    global              <- lift $ ask
-    namespaceOrVariable <- liftMaybe $ Global.resolved global t
-    liftMaybe            $ either (const Nothing) Just namespaceOrVariable
+tokenToQName :: Global -> Token -> Maybe QName
+tokenToQName global token = do
+    namespaceOrVariable <- Global.resolved global token
+    either (const Nothing) Just namespaceOrVariable
 
 getTypeSignatureOnHover :: Position -> Global -> Maybe Hover
-getTypeSignatureOnHover pos global = res where
-    readerAction = MaybeT.run   $ getTypeOnHover pos
-    res          = Identity.run $ ReaderT.run readerAction global
+getTypeSignatureOnHover = flip getTypeOnHover
 
-getTypeOnHover :: Position -> MaybeT RGlobal Hover
-getTypeOnHover pos = do
-    token      <- findToken pos
-    qname      <- tokenToQName token
-    symbol     <- findSymbol qname
-    symbolType <- lift $ getSymbolType symbol
+getTypeOnHover :: Global -> Position -> Maybe Hover
+getTypeOnHover global pos = do
+    token      <- findToken global pos
+    qname      <- tokenToQName global token
+    symbol     <- findSymbol global qname
+    symbolType  = getSymbolType global symbol
     pure        $ Hover 
         { 
             range   = tokenToRange token, 

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr
@@ -5,17 +5,14 @@ import ch.fhnw.thga.fregelanguageserver.compile.CompileNormalMode(compile)
 import ch.fhnw.thga.fregelanguageserver.types.Position(Position)
 import ch.fhnw.thga.fregelanguageserver.types.Range(Range, tokenToRange)
 
-import Compiler.types.Global(
-        StG, StIO, Message, Global, Severity(), Symbol, Symtab, IdInfo,
-        tokens, getST, liftStG, liftIO
-    )
+import Compiler.types.Global(Global, Symbol)
 import Compiler.types.Tokens(Token)
 import Test.QuickCheck(Property, once, morallyDubiousIOProperty)
 import Control.monad.Reader(ReaderT)
 import Control.monad.trans.MonadTrans (lift)
 import Control.monad.trans.MaybeT (MaybeT)
 import frege.ide.Utilities(label)
-import Data.List(find, sortBy)
+import Data.List(find)
 import Compiler.types.QNames(QName)
 import Control.arrow.Kleisli(Kleisli)
 import frege.data.wrapper.Identity(Identity)
@@ -65,9 +62,9 @@ findSymbol qname = MaybeT $ do
 
 tokenToQName :: Token -> MaybeT RGlobal QName
 tokenToQName t = do
-    global   <- lift $ Reader.ask
-    resolved <- liftMaybe $ Global.resolved global t
-    liftMaybe $ either (const empty) Just resolved
+    global              <- lift $ Reader.ask
+    namespaceOrVariable <- liftMaybe $ Global.resolved global t
+    liftMaybe            $ either (const Nothing) Just namespaceOrVariable
 
 getTypeSignatureOnHover :: Position -> Global -> Maybe Hover
 getTypeSignatureOnHover pos global = res where

--- a/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr
+++ b/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr
@@ -8,7 +8,7 @@ import ch.fhnw.thga.fregelanguageserver.types.Range(Range, tokenToRange)
 import Compiler.types.Global(Global, Symbol)
 import Compiler.types.Tokens(Token)
 import Test.QuickCheck(Property, once, morallyDubiousIOProperty)
-import Control.monad.Reader(ReaderT)
+import Control.monad.Reader(ReaderT, ask)
 import Control.monad.trans.MonadTrans (lift)
 import Control.monad.trans.MaybeT (MaybeT)
 import frege.ide.Utilities(label)
@@ -41,12 +41,12 @@ liftMaybe = maybe mzero return
 
 getSymbolType:: Symbol -> RGlobal String
 getSymbolType sym = do
-    global <- Reader.ask
+    global <- ask
     pure    $ label global sym
 
 findToken :: Position -> MaybeT RGlobal Token
 findToken pos = MaybeT $ do
-    global <- Reader.ask
+    global <- ask
     tokens  = listFromArray global.sub.toks
     pure    $ find isHoverOverToken tokens where
         isHoverOverToken :: Token -> Bool
@@ -57,18 +57,18 @@ findToken pos = MaybeT $ do
 
 findSymbol :: QName -> MaybeT RGlobal Symbol
 findSymbol qname = MaybeT $ do
-    global  <- Reader.ask
+    global  <- ask
     pure     $ Global.find global qname
 
 tokenToQName :: Token -> MaybeT RGlobal QName
 tokenToQName t = do
-    global              <- lift $ Reader.ask
+    global              <- lift $ ask
     namespaceOrVariable <- liftMaybe $ Global.resolved global t
     liftMaybe            $ either (const Nothing) Just namespaceOrVariable
 
 getTypeSignatureOnHover :: Position -> Global -> Maybe Hover
 getTypeSignatureOnHover pos global = res where
-    readerAction = MaybeT.run $ getTypeOnHover pos
+    readerAction = MaybeT.run   $ getTypeOnHover pos
     res          = Identity.run $ ReaderT.run readerAction global
 
 getTypeOnHover :: Position -> MaybeT RGlobal Hover
@@ -77,7 +77,7 @@ getTypeOnHover pos = do
     qname      <- tokenToQName token
     symbol     <- findSymbol qname
     symbolType <- lift $ getSymbolType symbol
-    pure $ Hover 
+    pure        $ Hover 
         { 
             range   = tokenToRange token, 
             content = FregeCodeBlock symbolType


### PR DESCRIPTION
Fixes #49.

The pure core only reads the `Global` state. As a result, I don't need the `State` monad and can replace it with the `Reader` monad to clearly reflect this requirement in the type system as well.

This provides an interesting design space with the following three options:

### No Transformers, just Thread/Passthrough the Global argument:

```frege
getTypeOnHover :: Global  -> Position -> Maybe Hover
getTypeOnHover gl pos = do
    token      <- findToken gl pos
    qname      <- tokenToQName gl token
    symbol     <- findSymbol gl qname
    symbolType  = getSymbolType gl symbol
    pure        $ Hover 
        { 
            range   = tokenToRange token, 
            content = FregeCodeBlock symbolType
        }
```

- Pros: Easier to understand because no monad transformers are involved, e.g. no `lift`.
- Cons: All intermediary functions need the additional `Global` parameter. This makes not only the high-level function `getTypeOnHover` more noisy but also all intermediary functions, which do not actually use the `Global` argument. In addition, nothing prevents the user to modify the `Global` between function calls (e.g. between the `findToken` and the `tokenToQName` step, which violates the assumption that the `Global` is an immutable Global data type.

### `MaybeT Reader Global a`

The code can be found on the [f-readerT](https://github.com/tricktron/frege-lsp-server/blob/a7241931652560324f8d8a4d585f3219081ebe10/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr) branch.

In order to combine it with the Maybe Monad, I opted for the `MaybeT` transformer monad. The `liftMaybe` function is responsible to lift `Maybe` values into the `MaybeT` monad and allows to combine the various search functions, which return `Maybe` values:

https://github.com/tricktron/frege-lsp-server/blob/a7241931652560324f8d8a4d585f3219081ebe10/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr#L39-L40

https://github.com/tricktron/frege-lsp-server/blob/a7241931652560324f8d8a4d585f3219081ebe10/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr#L74-L84

- Pros: Keeps the higher-level function `getTypeOnHover` simpler. The Global data type is immutable as default. You could still run a computation in a different environment using the `local` function. However, the user needs to actively do that.
- Cons:  The lower-level function become more complex because we now use monad transformers, which do the work, e.g. we need to use `lift` to jump around the monad stack.

### `ReaderT Maybe Global a` a.k.a `Kleisli Maybe Global a`

The code can be found on the [f-readerT-arrow](https://github.com/tricktron/frege-lsp-server/blob/7f790e28a9a9af3f1d4e5ee3b884250d94fd1fd0/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr) branch.

This stack has the same pros and cons as the `MaybeT Reader Global a` approach. However, it has some subtle differences:

`Kleisli m a b` is an instance of the `Arrow` type class and the monad type class in Frege. This is a major difference to Haskell where the` ReaderT` is **not** an `Arrow` instance.  According to the Haskell [Typeclassopedia](https://wiki.haskell.org/Typeclassopedia) an `Arrow` and a `Monad` is not the same but `Monad` and `ArrowApply` are the same.

I have never used the `Arrow` type class, so the following may be completely wrong and inaccurate:

Since `Kleisli` is not an instance of `MonadTrans` we cannot use the standard `lift` function, e.g:

```frege
findSymbol :: QName -> ReaderT Maybe Global Symbol
findSymbol qname = do
    global     <- ask
    lift       $ Global.find global qname -- fails because Kleisli Maybe is not an instance of MonadTrans
```

In Haskell this works because there is a MonadTrans instance of `ReaderT`. I did not manage to write a `MonadTrans (ReaderT)` instance in Frege. Instead I wrote another helper function `liftKleisli`:

https://github.com/tricktron/frege-lsp-server/blob/7f790e28a9a9af3f1d4e5ee3b884250d94fd1fd0/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr#L34-L35

The high-level `getTypeOnHover` function then looks like this:

https://github.com/tricktron/frege-lsp-server/blob/7f790e28a9a9af3f1d4e5ee3b884250d94fd1fd0/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr#L65-L75

Instead of `lift` I used the `arr` function to lift a function into `Kleisli m`. This has the advantage that I can keep the `getSymbolType` function even simpler without making it a `Reader`:

Using Arrow with Kleisli:
https://github.com/tricktron/frege-lsp-server/blob/7f790e28a9a9af3f1d4e5ee3b884250d94fd1fd0/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr#L37-L38

Vs. Using Monad with MaybeT:
https://github.com/tricktron/frege-lsp-server/blob/a7241931652560324f8d8a4d585f3219081ebe10/src/main/frege/ch/fhnw/thga/fregelanguageserver/hover/Hover.fr#L42-L45